### PR TITLE
Solar link batt temp

### DIFF
--- a/plugins/SolarLink/__init__.py
+++ b/plugins/SolarLink/__init__.py
@@ -136,7 +136,12 @@ class Util():
             temp_celsius = 128 - temp_celsius
         self.PowerDevice.entities.temperature_celsius = temp_celsius
         logging.debug("mDeviceTemperatureCelsius {}".format(self.PowerDevice.entities.temperature_celsius))
+        battery_temp_celsius = self.Bytes2Int(bs, 10, 1)
         logging.debug("mBatteryTemperature {}".format(int(bs[10])))
+        if battery_temp_celsius > 128:
+            battery_temp_celsius = 128 - battery_temp_celsius
+        self.PowerDevice.entities.battery_temperature_celsius = battery_temp_celsius
+        logging.debug("mBatteryTemperatureCelsius {}".format(self.PowerDevice.entities.battery_temperature_celsius))
         logging.debug("mLoadVoltage {} {} => {} V".format(int(bs[11]), int(bs[12]), self.Bytes2Int(bs, 11, 2) * 0.1))
         self.PowerDevice.entities.voltage = self.Bytes2Int(bs, 11, 2) * 0.1
         logging.debug("mLoadElectricity {} {} => {} A".format(int(bs[13]), int(bs[14]), self.Bytes2Int(bs, 13, 2) * 0.01))

--- a/solardevice.py
+++ b/solardevice.py
@@ -490,7 +490,7 @@ class PowerDevice():
     def temperature_fahrenheit(self, value):
         self.temperature = (value + 459.67) * (5/9) * 10
 
-     @property
+    @property
     def battery_temperature_celsius(self):
         return round((self.temperature - 2731) * 0.1, 1)
     @battery_temperature_celsius.setter

--- a/solardevice.py
+++ b/solardevice.py
@@ -486,7 +486,7 @@ class PowerDevice():
     def battery_temperature(self):
         return self._bkelvin['val']
     @battery_temperature.setter
-    def temperature(self, value):
+    def battery_temperature(self, value):
         self.validate('_bkelvin', value)
 
     @property

--- a/solardevice.py
+++ b/solardevice.py
@@ -221,7 +221,7 @@ class SolarDevice(gatt.Device):
             # We want celsius, not kelvin
             try:
                 self.datalogger.log(self.logger_name, 'temperature', self.entities.temperature_celsius)
-                self.datalogger.log(self.logger_name, 'temperature', self.entities.battery_temperature_celsius)
+                self.datalogger.log(self.logger_name, 'battery_temperature', self.entities.battery_temperature_celsius)
                 
             except:
                 pass

--- a/solardevice.py
+++ b/solardevice.py
@@ -221,6 +221,8 @@ class SolarDevice(gatt.Device):
             # We want celsius, not kelvin
             try:
                 self.datalogger.log(self.logger_name, 'temperature', self.entities.temperature_celsius)
+                self.datalogger.log(self.logger_name, 'temperature', self.entities.battery_temperature_celsius)
+                
             except:
                 pass
 
@@ -488,7 +490,19 @@ class PowerDevice():
     def temperature_fahrenheit(self, value):
         self.temperature = (value + 459.67) * (5/9) * 10
 
+     @property
+    def battery_temperature_celsius(self):
+        return round((self.temperature - 2731) * 0.1, 1)
+    @battery_temperature_celsius.setter
+    def battery_temperature_celsius(self, value):
+        self.temperature = (value * 10) + 2731
 
+    @property
+    def battery_temperature_fahrenheit(self):
+        return round(((self.temperature * 0.18) - 459.67), 1)
+    @battery_temperature_fahrenheit.setter
+    def battery_temperature_fahrenheit(self, value):
+        self.temperature = (value + 459.67) * (5/9) * 10
 
 
     @property

--- a/solardevice.py
+++ b/solardevice.py
@@ -336,6 +336,12 @@ class PowerDevice():
             'max': 3731,
             'maxdiff': 20
         }
+        self._bkelvin = {
+            'val': 2731,
+            'min': 1731,
+            'max': 3731,
+            'maxdiff': 20
+        }
         self._mcapacity = {
             'val': 0,
             'min': 0,
@@ -477,6 +483,13 @@ class PowerDevice():
         self.validate('_dkelvin', value)
 
     @property
+    def battery_temperature(self):
+        return self._bkelvin['val']
+    @battery_temperature.setter
+    def temperature(self, value):
+        self.validate('_bkelvin', value)
+
+    @property
     def temperature_celsius(self):
         return round((self.temperature - 2731) * 0.1, 1)
     @temperature_celsius.setter
@@ -492,10 +505,10 @@ class PowerDevice():
 
     @property
     def battery_temperature_celsius(self):
-        return round((self.temperature - 2731) * 0.1, 1)
+        return round((self.battery_temperature - 2731) * 0.1, 1)
     @battery_temperature_celsius.setter
     def battery_temperature_celsius(self, value):
-        self.temperature = (value * 10) + 2731
+        self.battery_temperature = (value * 10) + 2731
 
     @property
     def battery_temperature_fahrenheit(self):


### PR DESCRIPTION
Hi @Olen!  I have a battery temperature monitor and noticed you were already grabbing the data from the GATT characteristics so  I added some properties to the solardevice class and added it to the battery_temperature MQTT logger.  Let me know if you want anything changed to this before accepting the PR or feel free to create one off of my branch to merge.

I've tested this on a Renogy Rover 40a: Renogy BT-1 module and it appears to be working great.  My controller is always warmer than my temperature sensor and I'm showing a 7 degree Celsius difference.