### PR TITLE
BatteryDevice: Fix for cell_mvoltage -> cell_voltage

### DIFF
--- a/plugins/RenogyBatt/__init__.py
+++ b/plugins/RenogyBatt/__init__.py
@@ -208,8 +208,8 @@ class Util():
         for j in range(int(bs[4])):
             local_s = 5 + (j*2)
             logging.debug("CellmVoltage {} {} => {}".format(
-                int(bs[local_s]),int(bs[local_s+1]), self.Bytes2Int(bs, local_s, 2) * 10))
-            self.PowerDevice.entities.cell_mvoltage = (j+1,self.Bytes2Int(bs, local_s, 2) * 10)
+                int(bs[local_s]),int(bs[local_s+1]), self.Bytes2Int(bs, local_s, 2) * 100))
+            self.PowerDevice.entities.cell_mvoltage = (j+1,self.Bytes2Int(bs, local_s, 2) * 100)
         return
 
 

--- a/solardevice.py
+++ b/solardevice.py
@@ -913,13 +913,13 @@ class BatteryDevice(PowerDevice):
         cell_array = {}
         for cell in self._cell_mvoltage:
             cell_array[cell] = {
-                    'val' : (self._cell_mvoltage[cell]['val'] * .01)
+                    'val' : (self._cell_mvoltage[cell]['val'] * .001)
                     }
         return cell_array
     @cell_voltage.setter
     def cell_voltage(self, value):
         cell = value[0]
-        new_value = value[1] * 100
+        new_value = value[1] * 1000
         current_value = self._cell_mvoltage[cell]['val']
         if new_value > 0 and abs(new_value - current_value) > 10:
             self._cell_mvoltage[cell]['val'] = new_value


### PR DESCRIPTION
Properly shows mvoltage as millivolts 
+ Related adjustment in RenogyBatt