### PR TITLE
Add Threading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bullseye
+FROM python:3.11-slim-bullseye
 
 RUN apt update && apt -y install --no-install-recommends bluetooth build-essential cmake autoconf automake pkg-config libdbus-1-dev libglib2.0-dev libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
 

--- a/datalogger.py
+++ b/datalogger.py
@@ -59,10 +59,10 @@ class DataLoggerMqtt():
             else:
                 if not refresh:
                     self.delete_sensor(device, var)
-                time.sleep(1)
+                time.sleep(0.5)
                 self.create_sensor(device, var)
             self.sensors.append(topic)
-            time.sleep(0.2)
+            time.sleep(0.1)
         logging.debug("Publishing to MQTT {}: {} = {}".format(self.broker, topic, val))
         ret = self.client.publish(topic, val, retain=True)
         if "power_switch" in var and time.time() > self._listener_created[device, var] + 300:
@@ -227,7 +227,7 @@ class DataLogger():
             self.logdata[device] = {}
         if var not in self.logdata[device]:
             self.logdata[device][var] = {}
-            self.logdata[device][var]['ts'] = None
+            self.logdata[device][var]['ts'] = ts
             self.logdata[device][var]['value'] = None
 
         if self.logdata[device][var]['value'] != val:
@@ -235,7 +235,7 @@ class DataLogger():
             self.logdata[device][var]['value'] = val
             logging.info("[{}] Sending new data {}: {}".format(device, var, val))
             self.send_to_server(device, var, val)
-        elif self.logdata[device][var]['ts'] < datetime.now()-timedelta(minutes=1):
+        elif self.logdata[device][var]['ts'] < datetime.now()-timedelta(minutes=10):
             self.logdata[device][var]['ts'] = ts
             self.logdata[device][var]['value'] = val
             # logging.debug("Sending data to server due to long wait")

--- a/plugins/VEDirect/__init__.py
+++ b/plugins/VEDirect/__init__.py
@@ -13,9 +13,13 @@ class Config():
     WRITE_CHAR_UUID_POLLING  = "306b0002-b081-4037-83dc-e59fcc3cdfd0"
     WRITE_CHAR_UUID_COMMANDS = "306b0003-b081-4037-83dc-e59fcc3cdfd0"
 
-
 class Util():
     # https://community.victronenergy.com/storage/attachments/2273-vecan-registers-public.pdf
+    #
+    # After reboot, you need to pair the device
+    # Watch bluetoothctl for
+    # [agent] Enter passkey (number in 0-999999): 000000
+    #
     VREG_COMMANDS = {
         'VREC': 0x0001,
         'VACK': 0x0002,
@@ -119,6 +123,7 @@ class Util():
 
     def send_magic_packets(self):
         # Some kind of magic session init
+        #  See also https://github.com/vvvrrooomm/victron/blob/947e6bd98cd184dec7cb38ecf47954c0391dfe8f/victron_smartsolar.py
         write_characteristic = self.PowerDevice.device_write_characteristic_polling
 
         hs = "fa80ff"
@@ -130,13 +135,6 @@ class Util():
         value = bytearray.fromhex(hs)
         self.PowerDevice.characteristic_write_value(value, write_characteristic)
         time.sleep(0.1)
-        # c.write_value(b);
-
-        # Skal ikke dit...
-        # hs = "01"
-        # value = bytearray.fromhex(hs)
-        # self.PowerDevice.characteristic_write_value(value, write_characteristic)
-        # time.sleep(0.1)
         # c.write_value(b);
 
         # Send some data to the command-characteristics
@@ -157,14 +155,45 @@ class Util():
         self.PowerDevice.characteristic_write_value(value, write_characteristic)
         time.sleep(0.1)
 
+        # c = '306b0004-b081-4037-83dc-e59fcc3cdfd0'
+        # hs = "05008119ec0f05008119ec0e05008119010c0500"
+        # value  = bytearray.fromhex(hs)
+        # self.PowerDevice.characteristic_write_value(value, c)
+        # time.sleep(0.1)
+
+        hs = "81189005008119ec3f05008119ec12"
+        value  = bytearray.fromhex(hs)
+        self.PowerDevice.characteristic_write_value(value, write_characteristic)
+        time.sleep(0.1)
+
+        hs = "19ecdc05038119eceb05038119eced"
+        value  = bytearray.fromhex(hs)
+        self.PowerDevice.characteristic_write_value(value, write_characteristic)
+        time.sleep(5)
+
         # Poll for data
         write_characteristic = self.PowerDevice.device_write_characteristic_polling
-        # c = charactersistcs["306b0002-b081-4037-83dc-e59fcc3cdfd0"]
         hs = "f941"
         value  = bytearray.fromhex(hs)
         self.PowerDevice.characteristic_write_value(value, write_characteristic)
         time.sleep(0.1)
-        # c.write_value(b);
+
+        # Send some data to the command-characteristics
+        write_characteristic = self.PowerDevice.device_write_characteristic_commands
+
+        hs = "0600821893421027"
+        value = bytearray.fromhex(hs)
+        self.PowerDevice.characteristic_write_value(value, write_characteristic)
+        time.sleep(5)
+
+        # Poll for data
+        write_characteristic = self.PowerDevice.device_write_characteristic_polling
+        hs = "f941"
+        value  = bytearray.fromhex(hs)
+        self.PowerDevice.characteristic_write_value(value, write_characteristic)
+        time.sleep(0.1)
+
+
 
     def keep_alive(self):
         # ("0024", "0600821893421027"),


### PR DESCRIPTION
This PR moves the pollers and logging to different threads.
I have had issues with some of my devices, and reconnecting to a device have been blocking all other pollers and logging.

With this PR (which I am currently running myself) polling and logging has been moved to threads - with one poller thread for each device.  This ensures that issues with one device does not affect the polling and logging of other devices. 

