### PR TITLE
Add fix 100% CPU usage caused by threaded_logger 

### DIFF
--- a/solar-monitor.py
+++ b/solar-monitor.py
@@ -71,17 +71,21 @@ except Exception as e:
     logging.error(e)
     sys.exit(1)
 
-def threaded_logger(queue, datalogger):
+def threaded_logger(queue_obj, datalogger):
     x = time.time()
     try:
         while True:
-            if not queue.empty():
-                y = time.time()
-                if y > x + 1:
-                    logging.debug(f"Queue size = {queue.qsize()}")
-                    x = y
-                logger_name, item, value = queue.get()
+            try:
+                logger_name, item, value = queue_obj.get(timeout=1.0)
                 datalogger.log(logger_name, item, value)
+            except queue.Empty:
+                pass
+
+            y = time.time()
+            if y > x + 1:
+                if not queue_obj.empty():
+                    logging.debug(f"Queue size = {queue_obj.qsize()}")
+                x = y
     except Exception as e:
         logging.error(e)
         sys.exit(299)


### PR DESCRIPTION
In the new threaded implementation, threaded_logger constantly consumes 100% CPU time:

```
Total Samples 2236
GIL: 100.00%, Active: 113.00%, Threads: 6

  %Own   %Total  OwnTime  TotalTime  Function (filename)                                                                                                                                             
 65.00%  79.00%   14.90s    18.19s   empty (queue.py)
 18.00%  99.00%    4.06s    22.30s   threaded_logger (solar-monitor.py)    
```

Previously the code iterated perpetually calling empty() on the queue, hammering the CPU (and continually taking the GIL). 

This change calls get() with a 1 second timeout; if no data arrives we iterate as before.