### PR TITLE
fix: Phase 0 ship-blocker hotfix — broken shipped config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 solar-monitor.ini
 solar-monitor.log*
 __pycache__/
+.venv/
+.pytest_cache/
+.superpowers/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py

--- a/solar-monitor.ini.dist
+++ b/solar-monitor.ini.dist
@@ -29,12 +29,12 @@ mac = 11:11:11:11:11:11
 reconnect = False
 
 [inverter_1]
-type = VictronConnect
+type = VEDirect
 mac = 11:11:11:11:11:11
 reconnect = False
 
 [rectifier_1]
-type = VictronConnect
+type = VEDirect
 mac = 11:11:11:11:11:11
 reconnect = False
 

--- a/solar-monitor.ini.dist
+++ b/solar-monitor.ini.dist
@@ -40,8 +40,10 @@ reconnect = False
 
 
 [datalogger]
-url = http://server/solar/api/
-token = 39129e20be0503937cb72a5f719337cc
+# Uncomment and point this at your own HTTP ingest endpoint to enable the
+# JSON/HTTP datalogger. Leave commented out to use MQTT only.
+# url = https://server.example.com/solar/api/
+# token = your-token-here
 
 [mqtt]
 # Address to the mqtt broker

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,83 @@
+"""Test-only stubs so the BLE modules import without hardware.
+
+`gatt` is a Linux/dbus/BlueZ library that cannot be imported in CI. We install
+minimal fakes into sys.modules BEFORE any test imports solardevice.py.
+"""
+import sys
+import types
+
+
+def _install_dbus_stub():
+    if "dbus" in sys.modules:
+        return
+
+    exceptions = types.ModuleType("dbus.exceptions")
+
+    class DBusException(Exception):
+        pass
+
+    exceptions.DBusException = DBusException
+
+    dbus = types.ModuleType("dbus")
+    dbus.exceptions = exceptions
+
+    sys.modules["dbus"] = dbus
+    sys.modules["dbus.exceptions"] = exceptions
+
+
+def _install_gatt_stub():
+    if "gatt" in sys.modules:
+        return
+
+    errors = types.ModuleType("gatt.errors")
+
+    class _GattError(Exception):
+        pass
+
+    class InProgress(_GattError):
+        pass
+
+    class Failed(_GattError):
+        pass
+
+    errors.InProgress = InProgress
+    errors.Failed = Failed
+
+    gatt = types.ModuleType("gatt")
+
+    class DeviceManager:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class Device:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def connect(self):
+            pass
+
+        def connect_succeeded(self):
+            pass
+
+        def connect_failed(self, error):
+            pass
+
+        def disconnect_succeeded(self):
+            pass
+
+        def services_resolved(self):
+            pass
+
+        def characteristic_value_updated(self, characteristic, value):
+            pass
+
+    gatt.DeviceManager = DeviceManager
+    gatt.Device = Device
+    gatt.errors = errors
+
+    sys.modules["gatt"] = gatt
+    sys.modules["gatt.errors"] = errors
+
+
+_install_dbus_stub()
+_install_gatt_stub()

--- a/tests/test_harness_smoke.py
+++ b/tests/test_harness_smoke.py
@@ -1,0 +1,4 @@
+def test_gatt_stub_lets_solardevice_import():
+    import solardevice
+    assert hasattr(solardevice, "SolarDevice")
+    assert hasattr(solardevice, "SolarDeviceManager")

--- a/tests/test_shipped_config.py
+++ b/tests/test_shipped_config.py
@@ -1,0 +1,23 @@
+import configparser
+import os
+
+DIST = os.path.join(os.path.dirname(os.path.dirname(__file__)), "solar-monitor.ini.dist")
+
+
+def _read_dist():
+    cp = configparser.ConfigParser()
+    read = cp.read(DIST)
+    assert read, "solar-monitor.ini.dist should be readable"
+    return cp
+
+
+def test_every_device_type_maps_to_a_real_plugin():
+    cp = _read_dist()
+    plugins_dir = os.path.join(os.path.dirname(DIST), "plugins")
+    for section in cp.sections():
+        dtype = cp.get(section, "type", fallback=None)
+        if not dtype:
+            continue
+        assert os.path.isdir(os.path.join(plugins_dir, dtype)), (
+            f"[{section}] type = {dtype} has no plugins/{dtype} directory"
+        )

--- a/tests/test_shipped_config.py
+++ b/tests/test_shipped_config.py
@@ -21,3 +21,18 @@ def test_every_device_type_maps_to_a_real_plugin():
         assert os.path.isdir(os.path.join(plugins_dir, dtype)), (
             f"[{section}] type = {dtype} has no plugins/{dtype} directory"
         )
+
+
+def test_no_active_datalogger_url_by_default():
+    cp = _read_dist()
+    # A fresh install must not POST to a placeholder host on first run.
+    url = cp.get("datalogger", "url", fallback=None) if cp.has_section("datalogger") else None
+    assert not url, f"datalogger url should be commented out by default, got {url!r}"
+
+
+def test_no_credential_looking_token():
+    cp = _read_dist()
+    token = cp.get("datalogger", "token", fallback="") if cp.has_section("datalogger") else ""
+    assert token in ("", "your-token-here"), (
+        f"shipped token should be a placeholder, got {token!r}"
+    )


### PR DESCRIPTION
Closes #43.

Two shipped-config defects that break a fresh install following the README, plus the first test harness this repo has ever had.

## Fixes
- **`type = VictronConnect` → `VEDirect`** in `solar-monitor.ini.dist` (both device sections). `VictronConnect` is a plugin name that has never existed in the tree or history — it made Victron devices fail to import silently. Verified no other references remain.
- **Commented out the active `[datalogger]` block** (pointed at placeholder host `http://server/solar/api/`) and replaced the MD5-looking dummy token with `your-token-here`; example switched to `https://`. A default install no longer POSTs to an unreachable host on first run (which triggered the silent consumer-death hang tracked in #44).

## Test harness (enables everything downstream)
- `pytest.ini`, `tests/`, and a `conftest.py` that stubs `gatt` (and `dbus`) into `sys.modules` so the BLE modules import with no hardware.
- `tests/test_shipped_config.py`: asserts every device `type` maps to a real `plugins/<type>/` dir, and that the shipped config ships no active datalogger URL or credential-looking token. **4 passing.**

pytest is dev-only (a venv), not added to `requirements.txt`.

Part of the phased stabilization plan (design + plan in #48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)