### PR TITLE
feat: Phase 1 — supervision & liveness (stop the daemon dying silently while alive)

### DIFF
--- a/datalogger.py
+++ b/datalogger.py
@@ -259,9 +259,9 @@ class DataLogger():
             payload = {'device': device, var: val, 'ts': ts}
             header = {'Content-type': 'application/json', 'Accept': 'text/plain', 'Authorization': 'Bearer {}'.format(self.token)}
             try:
-                response = requests.post(url=self.url, json=payload, headers=header)
-            except TimeoutError:
-                logging.error("Connection to {} timed out!".format(self.url))
+                response = requests.post(url=self.url, json=payload, headers=header, timeout=(5, 10))
+            except requests.exceptions.RequestException as e:
+                logging.error("Failed to POST to {}: {}".format(self.url, e))
 
 
 

--- a/solar-monitor.py
+++ b/solar-monitor.py
@@ -13,6 +13,8 @@ import duallog
 import concurrent.futures
 import queue
 import threading
+import signal
+from supervisor import run_logger, LivenessTracker, supervise
 
 
 
@@ -62,6 +64,9 @@ duallog.setup('solar-monitor', minLevel=level, fileLevel=level, rotation='daily'
 # Create the message queue
 pipeline = queue.Queue(maxsize=10000)
 
+stop_event = threading.Event()
+liveness = LivenessTracker()
+
 # Set up data logging
 # datalogger = None
 try:
@@ -71,28 +76,11 @@ except Exception as e:
     logging.error(e)
     sys.exit(1)
 
-def threaded_logger(queue_obj, datalogger):
-    x = time.time()
-    try:
-        while True:
-            try:
-                logger_name, item, value = queue_obj.get(timeout=1.0)
-                datalogger.log(logger_name, item, value)
-            except queue.Empty:
-                pass
-
-            y = time.time()
-            if y > x + 1:
-                if not queue_obj.empty():
-                    logging.debug(f"Queue size = {queue_obj.qsize()}")
-                x = y
-    except Exception as e:
-        logging.error(e)
-        sys.exit(299)
-
 executor = concurrent.futures.ThreadPoolExecutor(max_workers=100)
 
-executor.submit(threaded_logger, pipeline, datalogger)
+logger_future = executor.submit(
+    run_logger, pipeline, datalogger, stop_event, liveness.record
+)
 
 # Set up device manager and adapter
 device_manager = SolarDeviceManager(adapter_name=config['monitor']['adapter'])
@@ -140,6 +128,7 @@ def threaded_poller(dev, device_manager, logger_name, config, datalogger, queue)
     device.connect()
 
 
+matched = 0
 for dev in device_manager.devices():
     logging.debug("Processing device {} {}".format(dev.mac_address, dev.alias()))
     for section in config.sections():
@@ -147,22 +136,47 @@ for dev in device_manager.devices():
             mac = config.get(section, "mac").lower()
             if dev.mac_address.lower() == mac:
                 executor.submit(threaded_poller, dev, device_manager, section, config, datalogger, pipeline)
+                liveness.expect(section)
+                matched += 1
                 logging.info("Waiting for device to connect")
                 time.sleep(1)
+                break
+
+if matched == 0:
+    logging.error("No configured devices were discovered; exiting for restart.")
+    stop_event.set()
+    sys.exit(1)
+
+
+def _handle_signal(signum, _frame):
+    logging.info("Received signal %s; shutting down.", signum)
+    stop_event.set()
+    device_manager.stop()
+
+
+signal.signal(signal.SIGTERM, _handle_signal)
+signal.signal(signal.SIGINT, _handle_signal)
 
 logging.debug("Waiting for devices to connect...")
 time.sleep(10)
-logging.info("Terminate with Ctrl+C")
-try:
-    device_manager.run()
-except KeyboardInterrupt:
-    pass
 
+# Run the gatt main loop on a background thread so the main thread can supervise.
+loop_thread = threading.Thread(target=device_manager.run, name="gatt-mainloop", daemon=True)
+loop_thread.start()
+
+logging.info("Supervising; terminate with Ctrl+C or SIGTERM")
+exit_code = supervise(device_manager, logger_future, liveness, stop_event,
+                      check_interval=30.0, stale_timeout=600.0)
+
+stop_event.set()
+device_manager.stop()
 for dev in device_manager.devices():
     try:
         dev.disconnect()
-    except:
-        pass
+    except Exception as e:
+        logging.warning("Error disconnecting %s: %s", getattr(dev, "mac_address", "?"), e)
+
+sys.exit(exit_code)
 
 
 

--- a/solar-monitor.service
+++ b/solar-monitor.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Solar Monitor
-After=network.target
+After=network.target bluetooth.service
+Wants=bluetooth.service
  
 [Service]
 Type=simple

--- a/solardevice.py
+++ b/solardevice.py
@@ -9,6 +9,7 @@ import time
 import os
 import sys
 import gatt
+from gi.repository import GLib
 import time
 from datetime import datetime
 from dbus.exceptions import DBusException
@@ -120,8 +121,21 @@ class SolarDevice(gatt.Device):
             super().connect()
         except DBusException as e:
             logging.error("[{}] DBUS-error: {}".format(self.logger_name, e))
-            time.sleep(10)
+            self._schedule_reconnect()
             # sys.exit(100)
+
+    def _schedule_reconnect(self):
+        """Schedule a reconnect on the main loop. Never sleeps, never recurses —
+        connect_failed -> connect() -> connect_failed() is a recursive cycle that
+        blows the stack after ~an hour of a device being unreachable."""
+        if not self.auto_reconnect:
+            return
+        logging.info("[{}] Reconnecting in 10 seconds...".format(self.logger_name))
+        GLib.timeout_add_seconds(10, self._reconnect_cb)
+
+    def _reconnect_cb(self):
+        self.connect()
+        return False  # one-shot: do not repeat
 
     def connect_succeeded(self):
         super().connect_succeeded()
@@ -138,11 +152,7 @@ class SolarDevice(gatt.Device):
             self.run_command_poller = False
             self.command_trigger.set()
             self.command_trigger.clear()
-        if self.auto_reconnect:
-            logging.info("[{}] Reconnecting in 10 seconds...".format(self.logger_name))
-            # self.sleeper.wait(10)
-            time.sleep(10)
-            self.connect()
+        self._schedule_reconnect()
 
 
     def disconnect_succeeded(self):
@@ -156,11 +166,7 @@ class SolarDevice(gatt.Device):
             self.run_command_poller = False
             self.command_trigger.set()
             self.command_trigger.clear()
-        if self.auto_reconnect:
-            logging.info("[{}] Reconnecting in 10 seconds".format(self.logger_name))
-            # self.sleeper.wait(10)
-            time.sleep(10)
-            self.connect()
+        self._schedule_reconnect()
 
     def services_resolved(self):
         super().services_resolved()

--- a/solardevice.py
+++ b/solardevice.py
@@ -16,6 +16,8 @@ from dbus.exceptions import DBusException
 # import duallog
 import logging
 
+from supervisor import try_put
+
 # duallog.setup('SmartPower', minLevel=logging.INFO)
 
 # from datalogger import DataLogger
@@ -58,6 +60,7 @@ class SolarDevice(gatt.Device):
         self.device_write_characteristic_commands = None
         self.datalogger = datalogger
         self.queue = queue
+        self._dropped = 0
         self.run_device_poller = False
         self.poller_thread = None
         self.run_command_poller = False
@@ -214,6 +217,18 @@ class SolarDevice(gatt.Device):
 
 
 
+    def _enqueue(self, item):
+        """Non-blocking enqueue. Dropping a sample is always better than
+        blocking the dbus main-loop thread inside a gatt callback."""
+        if not try_put(self.queue, item):
+            self._dropped += 1
+            if self._dropped % 100 == 1:
+                logging.warning(
+                    "[{}] Log queue full; dropped {} samples (consumer stalled?)".format(
+                        self.logger_name, self._dropped
+                    )
+                )
+
     def characteristic_value_updated(self, characteristic, value):
         super().characteristic_value_updated(characteristic, value)
 
@@ -235,15 +250,15 @@ class SolarDevice(gatt.Device):
             for item in items:
                 try:
                     logging.debug(f"Logging data: {self.logger_name}, {item}, {getattr(self.entities, item)}")
-                    self.queue.put((self.logger_name, item, getattr(self.entities, item)))
+                    self._enqueue((self.logger_name, item, getattr(self.entities, item)))
                 except Exception as e:
                     logging.debug("[{}] Could not find {}".format(self.logger_name, item))
                     pass
 
             # We want celsius, not kelvin
             try:
-                self.queue.put((self.logger_name, 'temperature', self.entities.temperature_celsius))
-                self.queue.put((self.logger_name, 'battery_temperature', self.entities.battery_temperature_celsius))
+                self._enqueue((self.logger_name, 'temperature', self.entities.temperature_celsius))
+                self._enqueue((self.logger_name, 'battery_temperature', self.entities.battery_temperature_celsius))
 
             except:
                 pass
@@ -252,7 +267,7 @@ class SolarDevice(gatt.Device):
             try:
                 for cell in self.entities.cell_mvoltage:
                     if self.entities.cell_mvoltage[cell]['val'] > 0:
-                        self.queue.put((self.logger_name, 'cell_{}'.format(cell), self.entities.cell_mvoltage[cell]['val']))
+                        self._enqueue((self.logger_name, 'cell_{}'.format(cell), self.entities.cell_mvoltage[cell]['val']))
             except:
                 pass
 
@@ -260,7 +275,7 @@ class SolarDevice(gatt.Device):
             try:
                 for cell in self.entities.cell_voltage:
                     if self.entities.cell_voltage[cell]['val'] > 0:
-                        self.queue.put((self.logger_name, 'cell_{}_voltage'.format(cell), self.entities.cell_voltage[cell]['val']))
+                        self._enqueue((self.logger_name, 'cell_{}_voltage'.format(cell), self.entities.cell_voltage[cell]['val']))
             except:
                 pass
 
@@ -713,7 +728,7 @@ class PowerDevice():
         if value != self._power_switch:
             self._power_switch = value
             try:
-                self.queue.put((self.logger_name, 'power_switch', self.power_switch))
+                self._enqueue((self.name, 'power_switch', self.power_switch))
             except:
                 pass
 

--- a/solardevice.py
+++ b/solardevice.py
@@ -728,7 +728,7 @@ class PowerDevice():
         if value != self._power_switch:
             self._power_switch = value
             try:
-                self._enqueue((self.name, 'power_switch', self.power_switch))
+                self.parent._enqueue((self.name, 'power_switch', self.power_switch))
             except:
                 pass
 

--- a/supervisor.py
+++ b/supervisor.py
@@ -15,3 +15,28 @@ def try_put(q, item):
         return True
     except queue.Full:
         return False
+
+
+def run_logger(queue_obj, datalogger, stop_event, on_item=None, get_time=time.time):
+    """Drain the queue into datalogger.log(), forever, until stop_event is set.
+
+    A per-item failure (sink down, decode bug) is logged and skipped — it must
+    NEVER terminate this loop, because the producers block behind a full queue.
+    """
+    last_report = get_time()
+    while not stop_event.is_set():
+        try:
+            logger_name, item, value = queue_obj.get(timeout=1.0)
+        except queue.Empty:
+            continue
+        try:
+            datalogger.log(logger_name, item, value)
+            if on_item is not None:
+                on_item(logger_name)
+        except Exception as e:
+            logging.error("datalogger.log failed for %s/%s: %s", logger_name, item, e)
+
+        now = get_time()
+        if now > last_report + 1 and not queue_obj.empty():
+            logging.debug("Queue size = %s", queue_obj.qsize())
+            last_report = now

--- a/supervisor.py
+++ b/supervisor.py
@@ -64,3 +64,28 @@ class LivenessTracker:
 
     def any_expected(self):
         return bool(self._last)
+
+
+def supervise(device_manager, logger_future, liveness, stop_event,
+              check_interval=30.0, stale_timeout=600.0, get_time=time.time,
+              on_tick=None):
+    """Watch the daemon's health until stop_event, then return an exit code.
+
+    Returns 1 (so systemd restarts) if the consumer thread died or every
+    expected device has gone stale; 0 on a clean requested stop.
+    """
+    while not stop_event.wait(check_interval):
+        if on_tick is not None:
+            on_tick()
+        if logger_future is not None and logger_future.done():
+            logging.error("Consumer thread has died; exiting for restart.")
+            device_manager.stop()
+            return 1
+        if liveness.any_expected():
+            stale = liveness.stale(stale_timeout)
+            if len(stale) == len(liveness._last):  # every expected device is stale
+                logging.error("No data from any device in %ss (%s); exiting for restart.",
+                              stale_timeout, ", ".join(sorted(stale)))
+                device_manager.stop()
+                return 1
+    return 0

--- a/supervisor.py
+++ b/supervisor.py
@@ -65,6 +65,10 @@ class LivenessTracker:
     def any_expected(self):
         return bool(self._last)
 
+    def expected_count(self):
+        """Number of devices registered via expect()."""
+        return len(self._last)
+
 
 def supervise(device_manager, logger_future, liveness, stop_event,
               check_interval=30.0, stale_timeout=600.0, get_time=time.time,
@@ -87,7 +91,7 @@ def supervise(device_manager, logger_future, liveness, stop_event,
             return 1
         if liveness.any_expected():
             stale = liveness.stale(stale_timeout)
-            if len(stale) == len(liveness._last):  # every expected device is stale
+            if len(stale) == liveness.expected_count():  # every expected device is stale
                 logging.error("No data from any device in %ss (%s); exiting for restart.",
                               stale_timeout, ", ".join(sorted(stale)))
                 device_manager.stop()

--- a/supervisor.py
+++ b/supervisor.py
@@ -40,3 +40,27 @@ def run_logger(queue_obj, datalogger, stop_event, on_item=None, get_time=time.ti
         if now > last_report + 1 and not queue_obj.empty():
             logging.debug("Queue size = %s", queue_obj.qsize())
             last_report = now
+
+
+class LivenessTracker:
+    """Tracks the last time each expected device produced a reading."""
+
+    def __init__(self, get_time=time.time):
+        self._get_time = get_time
+        self._last = {}
+
+    def expect(self, name):
+        """Register a device we require data from; seeds a baseline timestamp."""
+        self._last.setdefault(name, self._get_time())
+
+    def record(self, name):
+        """Note that `name` just produced a reading."""
+        self._last[name] = self._get_time()
+
+    def stale(self, timeout_s):
+        """Return the names with no reading within the last `timeout_s` seconds."""
+        now = self._get_time()
+        return [n for n, t in self._last.items() if now - t > timeout_s]
+
+    def any_expected(self):
+        return bool(self._last)

--- a/supervisor.py
+++ b/supervisor.py
@@ -1,0 +1,17 @@
+"""Hardware-free supervision helpers: queueing, the logger loop, liveness.
+
+This module deliberately does NOT import gatt so it can be unit-tested without
+Bluetooth. solar-monitor.py and solardevice.py import from here.
+"""
+import logging
+import queue
+import time
+
+
+def try_put(q, item):
+    """Enqueue without ever blocking. Returns True on success, False if full."""
+    try:
+        q.put_nowait(item)
+        return True
+    except queue.Full:
+        return False

--- a/supervisor.py
+++ b/supervisor.py
@@ -78,7 +78,11 @@ def supervise(device_manager, logger_future, liveness, stop_event,
         if on_tick is not None:
             on_tick()
         if logger_future is not None and logger_future.done():
-            logging.error("Consumer thread has died; exiting for restart.")
+            exc = logger_future.exception()
+            if exc is not None:
+                logging.error("Consumer thread died: %r; exiting for restart.", exc, exc_info=exc)
+            else:
+                logging.error("Consumer thread exited unexpectedly; exiting for restart.")
             device_manager.stop()
             return 1
         if liveness.any_expected():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,5 +79,26 @@ def _install_gatt_stub():
     sys.modules["gatt.errors"] = errors
 
 
+def _install_paho_stub():
+    """`paho-mqtt` is not installed in the test venv. datalogger.py only needs
+    `import paho.mqtt.client as paho` to succeed at module level — no test
+    exercises DataLogger.__init__ (which would call paho.Client(...)), so the
+    stub just needs to make that import resolve."""
+    if "paho" in sys.modules:
+        return
+
+    paho = types.ModuleType("paho")
+    mqtt = types.ModuleType("paho.mqtt")
+    client = types.ModuleType("paho.mqtt.client")
+
+    mqtt.client = client
+    paho.mqtt = mqtt
+
+    sys.modules["paho"] = paho
+    sys.modules["paho.mqtt"] = mqtt
+    sys.modules["paho.mqtt.client"] = client
+
+
 _install_dbus_stub()
 _install_gatt_stub()
+_install_paho_stub()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,9 +99,34 @@ def _install_paho_stub():
     sys.modules["paho.mqtt.client"] = client
 
 
+def _install_gi_stub():
+    """`gi` (PyGObject) is a system package, not pip-installable into a venv.
+    solardevice.py only needs `from gi.repository import GLib` to succeed at
+    module level — the `fake_glib` fixture below monkeypatches
+    `solardevice.GLib` for the reconnect tests, so this stub just needs a
+    harmless `timeout_add_seconds`."""
+    if "gi" in sys.modules:
+        return
+
+    gi = types.ModuleType("gi")
+    repository = types.ModuleType("gi.repository")
+
+    class GLib:
+        @staticmethod
+        def timeout_add_seconds(delay, callback):
+            return 1  # a fake source id
+
+    repository.GLib = GLib
+    gi.repository = repository
+
+    sys.modules["gi"] = gi
+    sys.modules["gi.repository"] = repository
+
+
 _install_dbus_stub()
 _install_gatt_stub()
 _install_paho_stub()
+_install_gi_stub()
 
 
 import pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -102,3 +102,23 @@ def _install_paho_stub():
 _install_dbus_stub()
 _install_gatt_stub()
 _install_paho_stub()
+
+
+import pytest
+
+
+class _FakeGLib:
+    def __init__(self):
+        self.scheduled = []  # list of (delay, callback)
+
+    def timeout_add_seconds(self, delay, callback):
+        self.scheduled.append((delay, callback))
+        return 1  # a fake source id
+
+
+@pytest.fixture
+def fake_glib(monkeypatch):
+    import solardevice
+    fake = _FakeGLib()
+    monkeypatch.setattr(solardevice, "GLib", fake, raising=False)
+    return fake

--- a/tests/test_datalogger_http.py
+++ b/tests/test_datalogger_http.py
@@ -1,0 +1,41 @@
+import types
+import sys
+import requests
+import datalogger
+
+
+def _make_url_only_logger(monkeypatch_url="http://unreachable.invalid/api"):
+    """Build a DataLogger with only the HTTP sink wired, bypassing __init__
+    (which needs a full config). We set just the attributes send_to_server uses."""
+    dl = datalogger.DataLogger.__new__(datalogger.DataLogger)
+    dl.url = monkeypatch_url
+    dl.token = "t"
+    dl.mqtt = None
+    dl.logdata = {}
+    return dl
+
+
+def test_post_is_called_with_a_timeout(monkeypatch):
+    calls = {}
+
+    def fake_post(*args, **kwargs):
+        calls.update(kwargs)
+
+        class _R:
+            status_code = 200
+        return _R()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    dl = _make_url_only_logger()
+    dl.send_to_server("reg", "voltage", 13.2)
+    assert "timeout" in calls and calls["timeout"] is not None
+
+
+def test_connection_error_is_swallowed_not_raised(monkeypatch):
+    def boom(*args, **kwargs):
+        raise requests.exceptions.ConnectionError("refused")
+
+    monkeypatch.setattr(requests, "post", boom)
+    dl = _make_url_only_logger()
+    # Must NOT raise — a network blip must never propagate to the consumer loop.
+    dl.send_to_server("reg", "voltage", 13.2)

--- a/tests/test_main_supervision.py
+++ b/tests/test_main_supervision.py
@@ -55,3 +55,27 @@ def test_supervise_returns_0_on_clean_stop():
     stop.set()  # already asked to stop
     rc = supervisor.supervise(dm, fut, lt, stop, check_interval=0.01, stale_timeout=30)
     assert rc == 0
+
+
+def test_supervise_does_not_exit_when_only_some_devices_stale():
+    # Two expected devices; "batt" keeps reporting while "reg" goes stale.
+    # supervise must NOT exit (all-stale, not any-stale). A regression to
+    # `if stale:` would return 1 here and fail this test.
+    clock = {"t": 0.0}
+    lt = supervisor.LivenessTracker(get_time=lambda: clock["t"])
+    lt.expect("reg")
+    lt.expect("batt")
+    dm = _FakeDM()
+    fut = _FakeFuture(done=False)
+    stop = threading.Event()
+
+    def tick():
+        clock["t"] += 100        # "reg" (last=0) is now stale...
+        lt.record("batt")        # ...but "batt" just reported, so it is fresh
+        stop.set()               # end the loop cleanly after this one check
+
+    rc = supervisor.supervise(
+        dm, fut, lt, stop, check_interval=0.01, stale_timeout=30, on_tick=tick,
+    )
+    assert rc == 0
+    assert dm.stopped is False

--- a/tests/test_main_supervision.py
+++ b/tests/test_main_supervision.py
@@ -1,0 +1,57 @@
+import threading
+import supervisor
+
+
+class _FakeFuture:
+    def __init__(self, done=False):
+        self._done = done
+
+    def done(self):
+        return self._done
+
+
+class _FakeDM:
+    def __init__(self):
+        self.stopped = False
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_supervise_exits_1_when_logger_future_dies():
+    dm = _FakeDM()
+    fut = _FakeFuture(done=True)  # consumer thread died
+    lt = supervisor.LivenessTracker()
+    stop = threading.Event()
+    rc = supervisor.supervise(dm, fut, lt, stop, check_interval=0.01, stale_timeout=999)
+    assert rc == 1
+    assert dm.stopped is True
+
+
+def test_supervise_exits_1_when_all_devices_stale():
+    clock = {"t": 0.0}
+    lt = supervisor.LivenessTracker(get_time=lambda: clock["t"])
+    lt.expect("reg")
+    dm = _FakeDM()
+    fut = _FakeFuture(done=False)
+    stop = threading.Event()
+
+    # advance the clock past the stale timeout on the first check
+    def tick():
+        clock["t"] += 100
+
+    rc = supervisor.supervise(
+        dm, fut, lt, stop, check_interval=0.01, stale_timeout=30,
+        get_time=lambda: clock["t"], on_tick=tick,
+    )
+    assert rc == 1
+
+
+def test_supervise_returns_0_on_clean_stop():
+    dm = _FakeDM()
+    fut = _FakeFuture(done=False)
+    lt = supervisor.LivenessTracker()  # nothing expected -> never stale
+    stop = threading.Event()
+    stop.set()  # already asked to stop
+    rc = supervisor.supervise(dm, fut, lt, stop, check_interval=0.01, stale_timeout=30)
+    assert rc == 0

--- a/tests/test_main_supervision.py
+++ b/tests/test_main_supervision.py
@@ -3,11 +3,15 @@ import supervisor
 
 
 class _FakeFuture:
-    def __init__(self, done=False):
+    def __init__(self, done=False, exc=None):
         self._done = done
+        self._exc = exc
 
     def done(self):
         return self._done
+
+    def exception(self):
+        return self._exc
 
 
 class _FakeDM:
@@ -26,6 +30,21 @@ def test_supervise_exits_1_when_logger_future_dies():
     rc = supervisor.supervise(dm, fut, lt, stop, check_interval=0.01, stale_timeout=999)
     assert rc == 1
     assert dm.stopped is True
+
+
+def test_supervise_logs_the_cause_when_consumer_dies(caplog):
+    # A restart is useless without the reason; the captured future exception
+    # must reach the log so a remote operator sees why the consumer died.
+    dm = _FakeDM()
+    boom = RuntimeError("sink exploded")
+    fut = _FakeFuture(done=True, exc=boom)
+    lt = supervisor.LivenessTracker()
+    stop = threading.Event()
+    with caplog.at_level("ERROR"):
+        rc = supervisor.supervise(dm, fut, lt, stop, check_interval=0.01, stale_timeout=999)
+    assert rc == 1
+    assert dm.stopped is True
+    assert "sink exploded" in caplog.text
 
 
 def test_supervise_exits_1_when_all_devices_stale():

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -1,0 +1,43 @@
+import solardevice
+
+
+def _reconnecting_device():
+    dev = solardevice.SolarDevice(mac_address="aa:bb:cc:dd:ee:ff", manager=None)
+    dev.auto_reconnect = True
+    dev.logger_name = "reg"
+    dev.poller_thread = None
+    dev.command_thread = None
+    return dev
+
+
+def test_schedule_reconnect_uses_glib_and_does_not_recurse(fake_glib):
+    dev = _reconnecting_device()
+    connect_calls = {"n": 0}
+    dev.connect = lambda: connect_calls.__setitem__("n", connect_calls["n"] + 1)
+
+    dev._schedule_reconnect()
+
+    # It scheduled a delayed retry rather than calling connect() synchronously.
+    assert connect_calls["n"] == 0
+    assert len(fake_glib.scheduled) == 1
+    delay, cb = fake_glib.scheduled[0]
+    assert delay == 10
+    # The scheduled callback returns False (one-shot) and calls connect once.
+    assert cb() is False
+    assert connect_calls["n"] == 1
+
+
+def test_schedule_reconnect_noop_when_disabled(fake_glib):
+    dev = _reconnecting_device()
+    dev.auto_reconnect = False
+    dev._schedule_reconnect()
+    assert fake_glib.scheduled == []
+
+
+import inspect
+
+
+def test_no_time_sleep_in_gatt_callbacks():
+    src = inspect.getsource(solardevice.SolarDevice.connect_failed)
+    src += inspect.getsource(solardevice.SolarDevice.disconnect_succeeded)
+    assert "time.sleep" not in src, "gatt callback must not block on time.sleep"

--- a/tests/test_solardevice_enqueue.py
+++ b/tests/test_solardevice_enqueue.py
@@ -35,3 +35,17 @@ def test_no_blocking_queue_put_calls_remain():
     assert not re.search(r"self\.queue\.put\(", src), (
         "found a blocking self.queue.put( in solardevice.py"
     )
+
+
+def test_power_device_power_switch_setter_enqueues_via_parent():
+    # PowerDevice is NOT a SolarDevice subclass; it holds a `parent` reference
+    # to the owning SolarDevice and has no _enqueue of its own. The setter
+    # must therefore call self.parent._enqueue(...), not self._enqueue(...).
+    dev = _make_device()
+    power_device = solardevice.PowerDevice(parent=dev)
+
+    power_device.power_switch = 1
+
+    assert dev.queue.qsize() == 1
+    assert dev.queue.get_nowait() == (dev.logger_name, "power_switch", 1)
+    assert dev._dropped == 0

--- a/tests/test_solardevice_enqueue.py
+++ b/tests/test_solardevice_enqueue.py
@@ -1,0 +1,37 @@
+import queue
+import re
+
+import solardevice  # conftest stubs gatt
+
+
+def _make_device():
+    # SolarDevice.__init__ returns early (no plugin import) when type is None,
+    # which is exactly the lightweight object we want for enqueue tests.
+    dev = solardevice.SolarDevice(
+        mac_address="11:22:33:44:55:66", manager=None, queue=queue.Queue(maxsize=1)
+    )
+    return dev
+
+
+def test_enqueue_puts_item_when_space():
+    dev = _make_device()
+    dev._enqueue(("regulator", "voltage", 13.2))
+    assert dev.queue.qsize() == 1
+    assert dev._dropped == 0
+
+
+def test_enqueue_drops_and_counts_when_full_without_blocking():
+    dev = _make_device()
+    dev._enqueue(("regulator", "voltage", 13.2))   # fills the maxsize=1 queue
+    dev._enqueue(("regulator", "current", 5.0))    # would block a real put(); must drop
+    assert dev.queue.qsize() == 1
+    assert dev._dropped == 1
+
+
+def test_no_blocking_queue_put_calls_remain():
+    with open("solardevice.py") as fh:
+        src = fh.read()
+    # self.queue.put( ... ) blocks; only self.queue.put_nowait / try_put allowed.
+    assert not re.search(r"self\.queue\.put\(", src), (
+        "found a blocking self.queue.put( in solardevice.py"
+    )

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,0 +1,16 @@
+import queue
+import supervisor
+
+
+def test_try_put_returns_true_when_space():
+    q = queue.Queue(maxsize=2)
+    assert supervisor.try_put(q, ("a", "b", 1)) is True
+    assert q.qsize() == 1
+
+
+def test_try_put_returns_false_when_full_and_does_not_block():
+    q = queue.Queue(maxsize=1)
+    assert supervisor.try_put(q, ("a", "b", 1)) is True
+    # Second put would block a blocking put() forever; try_put must return False.
+    assert supervisor.try_put(q, ("c", "d", 2)) is False
+    assert q.qsize() == 1

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,4 +1,7 @@
 import queue
+import threading
+import time
+
 import supervisor
 
 
@@ -14,3 +17,50 @@ def test_try_put_returns_false_when_full_and_does_not_block():
     # Second put would block a blocking put() forever; try_put must return False.
     assert supervisor.try_put(q, ("c", "d", 2)) is False
     assert q.qsize() == 1
+
+
+class _FlakyLogger:
+    def __init__(self):
+        self.logged = []
+        self.calls = 0
+
+    def log(self, name, item, value):
+        self.calls += 1
+        if self.calls == 1:
+            raise RuntimeError("transient sink failure")
+        self.logged.append((name, item, value))
+
+
+def test_run_logger_survives_a_sink_exception_and_keeps_going():
+    q = queue.Queue()
+    q.put(("reg", "voltage", 1))   # first call raises
+    q.put(("reg", "voltage", 2))   # must still be processed
+    stop = threading.Event()
+    logger = _FlakyLogger()
+    seen = []
+
+    t = threading.Thread(
+        target=supervisor.run_logger,
+        args=(q, logger, stop),
+        kwargs={"on_item": seen.append},
+    )
+    t.start()
+    # wait until both items drained, then stop
+    for _ in range(100):
+        if logger.logged:
+            break
+        time.sleep(0.02)
+    stop.set()
+    t.join(timeout=3)
+
+    assert not t.is_alive()               # loop did not die on the exception
+    assert ("reg", "voltage", 2) in logger.logged
+    assert "reg" in seen                  # on_item fired for the successful log
+
+
+def test_run_logger_stops_when_event_set():
+    q = queue.Queue()
+    stop = threading.Event()
+    stop.set()
+    # Should return promptly because stop is already set.
+    supervisor.run_logger(q, _FlakyLogger(), stop)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -92,3 +92,12 @@ def test_expect_seeds_a_baseline_so_a_never_reporting_device_goes_stale():
     clock["t"] = 100.0
     assert lt.stale(30) == ["reg"]
     assert lt.any_expected() is True
+
+
+def test_expected_count_reflects_registered_devices():
+    lt = supervisor.LivenessTracker()
+    assert lt.expected_count() == 0
+    lt.expect("reg")
+    lt.expect("batt")
+    lt.expect("reg")            # idempotent — same device, not double-counted
+    assert lt.expected_count() == 2

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -64,3 +64,31 @@ def test_run_logger_stops_when_event_set():
     stop.set()
     # Should return promptly because stop is already set.
     supervisor.run_logger(q, _FlakyLogger(), stop)
+
+
+def test_liveness_reports_stale_after_timeout():
+    clock = {"t": 1000.0}
+    lt = supervisor.LivenessTracker(get_time=lambda: clock["t"])
+    lt.expect("reg")
+    lt.record("reg")            # fresh at t=1000
+    clock["t"] = 1000.0 + 40
+    assert lt.stale(30) == ["reg"]      # 40s > 30s timeout
+
+
+def test_liveness_not_stale_when_recent():
+    clock = {"t": 500.0}
+    lt = supervisor.LivenessTracker(get_time=lambda: clock["t"])
+    lt.expect("reg")
+    clock["t"] = 500.0 + 10
+    lt.record("reg")            # recorded at t=510
+    clock["t"] = 500.0 + 20
+    assert lt.stale(30) == []           # only 10s since last record
+
+
+def test_expect_seeds_a_baseline_so_a_never_reporting_device_goes_stale():
+    clock = {"t": 0.0}
+    lt = supervisor.LivenessTracker(get_time=lambda: clock["t"])
+    lt.expect("reg")            # baseline at t=0, never records
+    clock["t"] = 100.0
+    assert lt.stale(30) == ["reg"]
+    assert lt.any_expected() is True


### PR DESCRIPTION
Closes #44.

The keystone fix. A five-way review found every serious fault ended in the same state: a thread dies or blocks, the process stays **alive**, and `Restart=always` never fires — silent multi-month outages on an off-grid Pi. This branch makes the daemon fail loudly (exit non-zero) or self-heal, so systemd's supervision actually works.

## Design rule
No gatt/dbus callback may block or recurse, and the process must exit non-zero on unrecoverable states. New logic lives in a **gatt-free `supervisor.py`** so it is unit-testable with no hardware; `tests/conftest.py` stubs gatt/dbus/paho/gi so the BLE modules import in CI.

## What changed
- **`threaded_logger` → `supervisor.run_logger`**: a consumer that catches per-item exceptions *inside* the loop and continues — a sink failure can never kill it. The old `sys.exit(299)` (which only killed the worker thread, leaving the process silently alive) is gone.
- **Non-blocking enqueue** (`supervisor.try_put` + `SolarDevice._enqueue`): all six blocking `self.queue.put()` sites drop-and-count on a full queue instead of blocking the dbus main-loop thread. Also fixes the `power_switch` setter's `AttributeError` (now enqueues via `self.parent._enqueue`, so switch-state pushes actually reach MQTT).
- **GLib-scheduled reconnect**: `connect_failed`/`disconnect_succeeded` no longer `time.sleep(10)` + recurse into `connect()` (a recursive cycle that blew the stack after ~55 min and stalled every device). They schedule a one-shot `GLib.timeout_add_seconds`.
- **Liveness watchdog** (`supervisor.LivenessTracker` + `supervise`): the main thread runs the gatt loop on a daemon thread and supervises — exits non-zero if the consumer future dies or **every** expected device goes stale.
- **Signals + zero-device exit**: SIGTERM/SIGINT set a stop event and stop the manager; zero matched devices exits non-zero instead of idling forever.
- **`requests.post` timeout + correct exception**: `timeout=(5,10)` and `except requests.exceptions.RequestException` (was `TimeoutError`, which never matched `ConnectionError`) — a network blip no longer escapes and kills the consumer.
- **Service ordered `After=bluetooth.service`** so startup discovery has an adapter.

## Tests
First real test suite for these modules — **24 passing**, hardware-free. Covers: non-blocking/drop-on-full enqueue, run_logger surviving sink exceptions, liveness staleness, the all-stale (not any-stale) exit condition, GLib reconnect non-recursion, and the HTTP timeout/exception fix.

## Deferred (documented, not this PR)
Full `Type=notify`+`sd_notify` watchdog and systemd hardening (Phase 4, #47); per-device reconnect config + thread-revival/lock fixes (Phase 3, #46); `main()` extraction (Phase 2, #45). CI note: the test venv needs `pip install pytest requests` (requests is a real runtime dep; gatt/dbus/paho/gi are stubbed).

Design + plan in #48. Built subagent-driven with per-task spec+quality review and a final adversarial whole-branch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)