### PR TITLE
Harden MQTT datalogger for Home Assistant + log timestamps

### DIFF
--- a/datalogger.py
+++ b/datalogger.py
@@ -33,15 +33,14 @@ class DataLoggerMqtt():
         # other service on the host that connects as the hostname; MQTT brokers
         # evict the older client on a duplicate id, so the two keep kicking each
         # other off — endless reconnects, and command subscriptions torn down
-        # every time (switches stop working). clean_session=False keeps the
-        # broker-side session (subscriptions + queued QoS1 commands) across the
-        # unreliable link's brief disconnects.
+        # every time. on_connect re-subscribes all command topics after any
+        # reconnect, which keeps switches working over an unreliable link.
         client_id = "solar-monitor-{}".format(hostname)
         cb_api_version = getattr(paho, "CallbackAPIVersion", None)
         if cb_api_version is not None:                                     #  create client object on paho-mqtt>=2.x
-            self.client = paho.Client(paho.CallbackAPIVersion.VERSION1, client_id, clean_session=False)
+            self.client = paho.Client(paho.CallbackAPIVersion.VERSION1, client_id)
         else:                                                              #  create client object on older paho-mqtt
-            self.client = paho.Client(client_id, clean_session=False)
+            self.client = paho.Client(client_id)
 
         if username and password:
             self.client.username_pw_set(username=username,password=password)
@@ -243,22 +242,40 @@ class DataLoggerMqtt():
                 logging.error("MQTT re-subscribe failed for {}: {}".format(topic, e))
 
     def on_subscribe(self, client, userdata, mid, granted_qos):
-        # logging.debug("Subscribed to MQTT topic {}".format(userdata))
-        pass
+        # granted_qos of 128 (0x80) means the broker DENIED the subscription
+        # (usually an ACL) — the client would then silently never receive on
+        # that topic, which is exactly how a command/switch subscription fails.
+        try:
+            denied = [q for q in granted_qos if q is not None and q >= 128]
+        except TypeError:
+            denied = []
+        if denied:
+            logging.error("MQTT subscription DENIED by broker (mid=%s granted_qos=%s) — check broker ACL", mid, granted_qos)
+        else:
+            logging.info("MQTT subscribed ok (mid=%s granted_qos=%s)", mid, granted_qos)
 
 
     def on_message(self, client, userdata, message):
-        topic = message.topic
-        payload = message.payload.decode("utf-8")
-        logging.info("MQTT message received {}".format(str(message.payload.decode("utf-8"))))
-        logging.debug("MQTT message topic={}".format(message.topic))
-        logging.debug("MQTT message qos={}".format(message.qos))
-        logging.debug("MQTT message retain flag={}".format(message.retain))
-        (prefix, device, var, crap) = topic.split("/")
-        self.sets[device].append((var, payload))
-        logging.info("MQTT set: {}".format(self.sets))
-        if self.trigger[device]:
-            self.trigger[device].set()
+        # This runs on the paho network-loop thread. An unhandled exception here
+        # kills that thread and takes the whole MQTT client down (no more state
+        # published, no more commands received) until the process restarts — so
+        # everything is guarded, and a device we don't yet track is created on
+        # the fly rather than raising KeyError.
+        try:
+            topic = message.topic
+            payload = message.payload.decode("utf-8")
+            logging.info("MQTT command received on {}: {}".format(topic, payload))
+            parts = topic.split("/")
+            if len(parts) < 4:                 # expect {prefix}/{device}/{var}/set
+                return
+            device, var = parts[-3], parts[-2]
+            self.sets.setdefault(device, []).append((var, payload))
+            trigger = self.trigger.get(device)
+            if trigger is not None:
+                trigger.set()
+        except Exception as e:
+            logging.error("MQTT on_message failed for {}: {}".format(
+                getattr(message, "topic", "?"), e))
 
     def on_log(self, client, userdata, level, buf):
         logging.debug("MQTT {}".format(buf))

--- a/datalogger.py
+++ b/datalogger.py
@@ -10,19 +10,38 @@ import socket
 
 
 class DataLoggerMqtt():
-    def __init__(self, broker, port, prefix=None, username=None, password=None, hostname=None):
+    def __init__(self, broker, port, prefix=None, username=None, password=None, hostname=None, device_types=None):
         logging.debug("Creating new MQTT-logger")
         if prefix == None:
             prefix = "solar-monitor"
         self.broker = broker
+        # section -> plugin type (e.g. "battery_1" -> "Meritsun"); used to group
+        # each physical unit's entities into a Home Assistant Device.
+        self.device_types = device_types or {}
+        # section -> BLE advertised alias (e.g. "12V100Ah-081"); filled in when a
+        # device resolves, shown as the HA Device model.
+        self.aliases = {}
+        # Command (.../set) topics we must stay subscribed to. The broker drops
+        # subscriptions on every reconnect (clean session), so on_connect
+        # re-subscribes these — without it, switches stop responding after the
+        # first network blip on an unreliable link.
+        self._command_topics = set()
         if not hostname:
             hostname = socket.gethostname()
 
+        # A UNIQUE, stable client id. Using the bare hostname collides with any
+        # other service on the host that connects as the hostname; MQTT brokers
+        # evict the older client on a duplicate id, so the two keep kicking each
+        # other off — endless reconnects, and command subscriptions torn down
+        # every time (switches stop working). clean_session=False keeps the
+        # broker-side session (subscriptions + queued QoS1 commands) across the
+        # unreliable link's brief disconnects.
+        client_id = "solar-monitor-{}".format(hostname)
         cb_api_version = getattr(paho, "CallbackAPIVersion", None)
         if cb_api_version is not None:                                     #  create client object on paho-mqtt>=2.x
-            self.client = paho.Client(paho.CallbackAPIVersion.VERSION1, "{}".format(hostname))
+            self.client = paho.Client(paho.CallbackAPIVersion.VERSION1, client_id, clean_session=False)
         else:                                                              #  create client object on older paho-mqtt
-            self.client = paho.Client("{}".format(hostname))
+            self.client = paho.Client(client_id, clean_session=False)
 
         if username and password:
             self.client.username_pw_set(username=username,password=password)
@@ -30,6 +49,7 @@ class DataLoggerMqtt():
         self.client.on_publish = self.on_publish                            # assign function to callback
         self.client.on_message = self.on_message                            # attach function to callback
         self.client.on_subscribe = self.on_subscribe                        # attach function to callback
+        self.client.on_connect = self.on_connect                            # re-subscribe on (re)connect
         self.client.on_log = self.on_log
 
         self.client.connect(broker, port)                                   # establish connection
@@ -57,35 +77,77 @@ class DataLoggerMqtt():
         topic = "{}{}/{}/state".format(self.prefix, device, var)
         if topic not in self.sensors or refresh:
             if "power_switch" in var:
-                # self.delete_switch(device, var)
-                # time.sleep(1)
                 self.create_switch(device, var)
                 self.create_listener(device, var)
             else:
-                if not refresh:
-                    self.delete_sensor(device, var)
-                time.sleep(0.5)
+                # Publish (or refresh) the retained discovery config. Do NOT
+                # delete it first: a retained config republish updates HA in
+                # place, whereas deleting removes the entity and — if the
+                # recreate is lost on an unreliable link — leaves it gone in HA
+                # even though the broker still retains the config. This is why
+                # entities went missing after a container restart, which resets
+                # self.sensors and so re-ran this block for every entity.
                 self.create_sensor(device, var)
             self.sensors.append(topic)
-            time.sleep(0.1)
         logging.debug("Publishing to MQTT {}: {} = {}".format(self.broker, topic, val))
-        ret = self.client.publish(topic, val, retain=True)
+        # Switch state at QoS 1 so a toggle during a disconnect is delivered on
+        # reconnect rather than silently dropped; high-frequency sensor state
+        # stays QoS 0 (it refreshes constantly anyway).
+        qos = 1 if "power_switch" in var else 0
+        ret = self.client.publish(topic, val, qos=qos, retain=True)
         if "power_switch" in var and time.time() > self._listener_created[device, var] + 300:
             self.create_listener(device, var)
+
+    def _device_block(self, device):
+        """The Home Assistant 'device' object shared by every entity of one
+        physical unit. Entities carrying the same identifiers are grouped under
+        a single Device in HA (e.g. all of battery_1's sensors)."""
+        block = {
+            "identifiers": ["{}_{}".format(self.prefix[:-1], device)],
+            "name": "{} {}".format(self.prefix[:-1].capitalize(),
+                                    device.replace("_", " ").title()),
+        }
+        dtype = self.device_types.get(device)
+        if dtype:
+            block["manufacturer"] = dtype        # plugin/protocol, e.g. Meritsun
+        alias = self.aliases.get(device)
+        if alias:
+            block["model"] = alias               # BLE advertised name, e.g. 12V100Ah-081
+        elif dtype:
+            block["model"] = dtype
+        return block
+
+    def set_device_alias(self, device, alias):
+        """Record a device's BLE advertised alias for its HA Device 'model'.
+        Called when the device resolves, before its entities are created."""
+        if alias:
+            self.aliases[device.strip()] = alias.strip()
+
+    def set_available(self, device, online):
+        """Publish a device's availability so HA shows all its entities as
+        'Unavailable' (not a stale value) when it is not connected."""
+        topic = "{}{}/availability".format(self.prefix, device.strip())
+        self.client.publish(topic, "online" if online else "offline", qos=1, retain=True)
 
     def create_switch(self, device, var):
         topic = "{}{}/{}/state".format(self.prefix, device, var)
         logging.debug("Creating MQTT-switch {}".format(topic))
         ha_topic = "homeassistant/switch/{}/{}/config".format(device, var)
         val = {
-            "name": "{} {} {}".format(self.prefix[:-1].capitalize(), device.replace("_", " ").title(), var.replace("_", " ").title()),
+            "name": var.replace("_", " ").title(),
             "unique_id": "{}_{}_{}".format(self.prefix[:-1], device, var),
             "state_topic": topic,
             "command_topic": "{}{}/{}/set".format(self.prefix, device, var),
             "payload_on": 1,
             "payload_off": 0,
+            "device": self._device_block(device),
+            "availability_topic": "{}{}/availability".format(self.prefix, device),
+            "payload_available": "online",
+            "payload_not_available": "offline",
         }
-        ret = self.client.publish(ha_topic, json.dumps(val), retain=True)
+        # QoS 1: discovery configs must survive an unreliable link, or the entity
+        # never appears in Home Assistant.
+        ret = self.client.publish(ha_topic, json.dumps(val), qos=1, retain=True)
 
 
     def create_sensor(self, device, var):
@@ -93,10 +155,14 @@ class DataLoggerMqtt():
         logging.debug("Creating MQTT-sensor {}".format(topic))
         ha_topic = "homeassistant/sensor/{}/{}/config".format(device, var)
         val = {
-            "name": "{} {} {}".format(self.prefix[:-1].capitalize(), device.replace("_", " ").title(), var.replace("_", " ").title()),
+            "name": var.replace("_", " ").title(),
             "unique_id": "{}_{}_{}".format(self.prefix[:-1], device, var),
             "state_topic": topic,
             "force_update": True,
+            "device": self._device_block(device),
+            "availability_topic": "{}{}/availability".format(self.prefix, device),
+            "payload_available": "online",
+            "payload_not_available": "offline",
         }
         if var == "temperature":
             val['device_class'] = "temperature"
@@ -135,7 +201,9 @@ class DataLoggerMqtt():
         elif "rectifier" in device:
             val['icon'] = "mdi:current-ac"
 
-        ret = self.client.publish(ha_topic, json.dumps(val), retain=True)
+        # QoS 1: discovery configs must survive an unreliable link, or the entity
+        # never appears in Home Assistant.
+        ret = self.client.publish(ha_topic, json.dumps(val), qos=1, retain=True)
 
     def delete_switch(self, device, var):
         ha_topic = "homeassistant/switch/{}/{}/config".format(device, var)
@@ -148,17 +216,31 @@ class DataLoggerMqtt():
     def create_listener(self, device, var):
         topic = "{}{}/{}/set".format(self.prefix, device, var)
         logging.info("Creating MQTT-listener {}".format(topic))
+        self._command_topics.add(topic)
         try:
-            self.client.subscribe((topic, 0))
+            self.client.subscribe((topic, 1))
             self._listener_created[device, var] = time.time()
         except Exception as e:
             logging.error("MQTT: {}".format(e))
-        self.sets[device] = []
+        self.sets.setdefault(device, [])
 
 
 
     def on_publish(self, client, userdata, result):             #create function for callback
         logging.debug("Published to MQTT")
+
+    def on_connect(self, client, userdata, flags, rc):
+        # The broker drops subscriptions on reconnect (clean session), so
+        # re-subscribe every command topic here — otherwise switches go dead
+        # after the first network blip. Runs on the initial connect too.
+        if self._command_topics:
+            logging.info("MQTT (re)connected (rc=%s); re-subscribing %d command topic(s)",
+                         rc, len(self._command_topics))
+        for topic in self._command_topics:
+            try:
+                client.subscribe((topic, 1))
+            except Exception as e:
+                logging.error("MQTT re-subscribe failed for {}: {}".format(topic, e))
 
     def on_subscribe(self, client, userdata, mid, granted_qos):
         # logging.debug("Subscribed to MQTT topic {}".format(userdata))
@@ -201,13 +283,19 @@ class DataLogger():
             self.url = config.get('datalogger', 'url')
             self.token = config.get('datalogger', 'token')
         if config.get('mqtt', 'broker', fallback=None):
+            device_types = {}
+            for section in config.sections():
+                dtype = config.get(section, 'type', fallback=None)
+                if dtype and config.get(section, 'mac', fallback=None):
+                    device_types[section] = dtype
             self.mqtt = DataLoggerMqtt(
                 config.get('mqtt', 'broker'),
                 config.get('mqtt', 'port', fallback=1883),
                 prefix=config.get('mqtt', 'prefix', fallback=None),
                 username=config.get('mqtt', 'username', fallback=None),
                 password=config.get('mqtt', 'password', fallback=None),
-                hostname=config.get('mqtt', 'hostname', fallback=None)
+                hostname=config.get('mqtt', 'hostname', fallback=None),
+                device_types=device_types
             )
         self.logdata = {}
 
@@ -220,6 +308,17 @@ class DataLogger():
     #
     #
     # }
+
+    def set_device_alias(self, device, alias):
+        """Record a device's BLE alias so the MQTT logger can show it as the HA
+        Device model. No-op when MQTT is not configured."""
+        if self.mqtt:
+            self.mqtt.set_device_alias(device, alias)
+
+    def set_available(self, device, online):
+        """Mark a device online/offline in HA. No-op without MQTT."""
+        if self.mqtt:
+            self.mqtt.set_available(device, online)
 
     def log(self, device, var, val):
         # Only log modified data

--- a/duallog.py
+++ b/duallog.py
@@ -30,7 +30,9 @@ file_name_format = '{year:04d}{month:02d}{day:02d}-'\
 
 # Define the default logging message formats.
 file_msg_format = '%(asctime)s %(levelname)-8s: %(message)s'
-console_msg_format = '%(levelname)s: %(message)s'
+# Include the timestamp on the console too — this is what `docker logs` captures,
+# and undated lines are impossible to correlate when debugging.
+console_msg_format = '%(asctime)s %(levelname)s: %(message)s'
 
 # Define the log rotation criteria.
 max_bytes=1024**2


### PR DESCRIPTION
Hardening of the MQTT datalogger for Home Assistant over an unreliable link, plus console log timestamps. Independent of the bleak work; touches only `datalogger.py` and `duallog.py`.

## datalogger.py
- Stop deleting-then-recreating discovery configs (was causing missing HA entities); publish discovery with QoS 1.
- Group entities under a real HA **Device** (`identifiers`/`manufacturer`/`model`), using the BLE advertised alias as the model.
- Per-device **availability** topic so a device that never connects (e.g. a dead battery) shows Unavailable instead of a stale last value.
- Unique MQTT client id (`solar-monitor-<hostname>`); re-subscribe all command topics on (re)connect so switches keep responding after a broker drop.
- **Guard `on_message`**: an unhandled `KeyError` there was crashing paho's loop thread on any switch command, which killed *all* publishing and command handling. It can no longer take the client thread down.

## duallog.py
- Timestamp console log lines (`%(asctime)s`), matching the file logs.

## Notes
- No behaviour change to the BLE layer; `pytest` green (35 passing), byte-compile clean.
- **Merge this before the bleak-transport PR** — that PR's `monitor_app.py` calls the new `datalogger.set_available()` / `set_device_alias()` added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
