### PR TITLE
Robust Meritsun frame parsing for post-BlueZ-5.82 stream

### DIFF
--- a/plugins/Meritsun/__init__.py
+++ b/plugins/Meritsun/__init__.py
@@ -57,6 +57,15 @@ class Util():
         self.PowerDevice = power_device
         self.end = 0
         self.prev_values = []
+        # A real full data frame carries this constant field (ASCII hex) at a fixed
+        # byte offset from the START_VAL marker. The pack also emits shorter status/
+        # other packet types (different layout) and the post-upgrade BlueZ stream
+        # duplicates fragments inside frames; both start with the same marker but
+        # decode to garbage. Requiring this signature at its fixed offset is what
+        # separates real data frames from the rest -- validated on both packs across
+        # charge and discharge with zero good frames lost.
+        self.DATA_SIGNATURE = b"0B008087"
+        self.DATA_SIGNATURE_OFFSET = 35
 
     def getValue(self, buf, start, end):
         try:
@@ -128,96 +137,99 @@ class Util():
 
     def notificationUpdate(self, data, char):
         # Gets the binary data from the BLE-device and converts it to a list of hex-values
-        logging.debug("broadcastUpdate Start {} {}".format(data, data.hex()))
         if self.PowerDevice.config.getboolean('monitor', 'debug', fallback=False):
             with open(f"/tmp/{self.PowerDevice.alias()}.log", 'a') as debugfile:
                 debugfile.write(f"{datetime.now()} <- {data.hex()}\n")
 
-        # logging.debug("broadcastUpdate Start {} {}".format(data, self.RevBuf))
-        # logging.debug("RevIndex {}".format(self.Revindex))
-        # logging.debug("SOI {}".format(self.SOI))
-        # logging.debug("RecvDataType start {}".format(self.Revindex))
-        cmdData = ""
-        if data != None and len(data):
-            i = 0
-            while i < len(data):
-                # logging.debug("Revindex {} {} Data: {}".format(i, self.Revindex, data[i]))
-                # logging.debug("RevBuf begin {}".format(self.RevBuf))
-                if self.Revindex > 121:
-                    # We have read more than 121 bytes, and don't care about the rest
-                    # logging.debug("Revindex  > 121 - parsing done")
-                    self.Revindex = 0
-                    self.end = 0
-                    self.RecvDataType = self.SOI
-
-                if self.RecvDataType == self.SOI:
-                    # 1. We start here, reading byte by byte until we get to the number 146 (hex 92)
-                    # Example: 30 30 30 35 39 35 0c 0c 0c 0c 0c 0c 0c 0c 92 37 37
-                    #                                                    ^^
-
-                    if data[i] == self.START_VAL:
-                        # When we find 146, we start filling the message buffer, and set a flag to read more data:
-                        self.RecvDataType = self.INFO
-                        self.RevBuf[self.Revindex] = data[i]
-                        self.Revindex = self.Revindex + 1
-                elif self.RecvDataType == self.INFO:
-                    # 2. The INFO-flag i set, lets continue to fill the buffer
-
-                    self.RevBuf[self.Revindex] = data[i]
-                    self.Revindex = self.Revindex + 1
-
-                    # The number 12 (hex 0C) marks the end of the message
-                    if data[i] == self.END_VAL:
-                        if self.end < 110:
-                            # Not sure why we need this...
-                            self.end = self.Revindex
-                        if self.Revindex == 121:
-                            # We have read 121 bytes and that marks the end of the buffer
-                            self.RecvDataType = self.EOI
-                elif self.RecvDataType == self.EOI:
-                    # 3. We should now have a buffer with 121 bytes,
-                    # starting with the first byte after value 146 (hex 92)
-
-                    # logging.debug("RecvDataType == 3 -> EOI")
-                    # logging.debug("Validate Checksum: {}".format(self.validateChecksum(self.RevBuf)))
-                    if self.validateChecksum(self.RevBuf):
-                        cmdData = self.RevBuf[1:self.Revindex]
-                        self.Revindex = 0
-                        self.end = 0
-                        self.RecvDataType = self.SOI
-                        return self.handleMessage(cmdData)
-                    self.Revindex = 0
-                    self.end = 0
-                    self.RecvDataType = self.SOI
-                i += 1
-        # logging.debug("broadcastUpdate End cmdData: {} RevBuf {}".format(cmdData, self.RevBuf))
-        return False
-
-
-
-
-
-
-    def handleMessage(self, message):
-        # Accepts a list of hex-characters, and returns the human readable values into the powerDevice object
-        # 2024-03-22 10:22:51,195 DEBUG   : handleMessage [56, 49, 51, 54, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 65, 48, 57, 65, 48, 49, 48, 48, 51, 53, 48, 48, 54, 52, 48, 48, 67, 56, 48, 65, 56, 48, 56, 56, 48, 55, 66, 54, 56, 50, 48, 69, 54, 50, 48, 68, 55, 53, 48, 68, 50, 56, 48, 68, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 54, 68, 56, 12, 12, 12, 12, 12, 12, 12, 12]
-
-        logging.debug("handleMessage {}".format(message))
-        if message == None or "" == message:
+        if not data:
             return False
-        if message != self.prev_values:
-            logging.debug("Response changed:")
-            logging.debug(f"- {self.prev_values}")
-            logging.debug(f"+ {message}:")
+
+        # The device streams several packet types back-to-back. A data packet
+        # starts with START_VAL (0x92); another packet type starts with 0xC9.
+        # Neither marker, nor the END_VAL (0x0C) padding, ever appears inside the
+        # ASCII-hex payload, so the markers delimit packets unambiguously. We
+        # accumulate the stream and re-sync on every marker, so a single lost or
+        # reframed notification can no longer desync the parser permanently the
+        # way the old fixed-121-byte logic did (which, after the trixie/BlueZ 5.82
+        # notification-framing change, gave up after the first frame). Unknown,
+        # short or corrupt packets are simply skipped.
+        if not hasattr(self, '_stream'):
+            self._stream = bytearray()
+        self._stream.extend(data)
+        # Bound the buffer so a marker-less run can't grow without limit.
+        if len(self._stream) > 512:
+            keep = max(self._stream.rfind(self.START_VAL), self._stream.rfind(0xC9))
+            self._stream = self._stream[keep:] if keep > 0 else self._stream[-256:]
+
+        updated = False
+        while True:
+            start = self._stream.find(self.START_VAL)
+            if start < 0:
+                # No data packet forming; drop the (unhandled) leading bytes.
+                self._stream.clear()
+                break
+            nxt = -1
+            for mark in (self.START_VAL, 0xC9):
+                p = self._stream.find(mark, start + 1)
+                if p >= 0 and (nxt < 0 or p < nxt):
+                    nxt = p
+            if nxt < 0:
+                # Packet not terminated yet (next marker unseen); keep it buffered.
+                if start > 0:
+                    del self._stream[:start]
+                break
+            packet = self._stream[start:nxt]   # START_VAL + payload + 0x0C padding
+            del self._stream[:nxt]             # consume; keep next marker as the new start
+            if self._handleDataPacket(packet):
+                updated = True
+        return updated
+
+    def _handleDataPacket(self, packet):
+        # packet[0] == START_VAL. Only real data frames carry DATA_SIGNATURE at its
+        # fixed offset; require it to reject the interleaved status/other packet
+        # types and mis-framed fragments (all of which decode to garbage). The
+        # scalar head stays intact even in fragment-bloated frames, so this is
+        # enough to trust the scalars; cells live further in and only survive in
+        # non-bloated frames, so gate them on length as well.
+        if packet.find(self.DATA_SIGNATURE) != self.DATA_SIGNATURE_OFFSET:
+            return False
+        end = packet.find(self.END_VAL)
+        if end < 0:
+            end = len(packet)
+        buf = [0] * 122
+        for k in range(min(len(packet), 122)):
+            buf[k] = packet[k]
+        self.RevBuf = buf
+        self.Revindex = min(len(packet), 121)
+        self.end = end
+        full_frame = len(packet) <= 130
+        return self.handleMessage(buf[1:self.Revindex], full=full_frame)
+
+
+
+
+
+
+    def handleMessage(self, message, full=True):
+        # Accepts a list of hex-characters, and returns the human readable values into the powerDevice object
+        logging.debug("handleMessage {}".format(message))
+        if not message or len(message) < 38:
+            return False
         self.prev_values = message
 
-        if len(message) < 38:
-            logging.info("len message < 38: {}".format(len(message)))
+        # A real pack always reports a nonzero pack voltage; a frame decoding it as
+        # 0 is not a data frame at all. (The DATA_SIGNATURE gate already rejects the
+        # other packet types; this is a cheap backstop.)
+        mvoltage = self.getValue(message, 0, 7)
+        if mvoltage < 1000:
             return False
 
         self.PowerDevice.entities.msg = message
-        # if self.DeviceType == '12V100Ah-027':
-        self.PowerDevice.entities.mvoltage = self.getValue(message, 0, 7)
+        # Scalar fields occupy the first 38 bytes of the frame. They sit at the
+        # head, before the region the duplicated fragments corrupt, so they are
+        # decoded on every framed packet; each entity setter validates its own
+        # value against physical bounds and rejects any that slipped through.
+        self.PowerDevice.entities.mvoltage = mvoltage
         mcurrent = self.getValue(message, 8, 15)
         if mcurrent > 2147483647:
             mcurrent = mcurrent - 4294967295
@@ -227,11 +239,25 @@ class Util():
         self.PowerDevice.entities.soc = self.getValue(message, 28, 31)
         self.PowerDevice.entities.temperature = self.getValue(message, 32, 35)
         self.PowerDevice.entities.status = self.getValue(message, 36, 37)
-        self.PowerDevice.entities.afestatus = self.getValue(message, 40, 41)
-        i = 0
-        while i < 16:
-            self.PowerDevice.entities.cell_mvoltage = (i + 1, self.getValue(message, (i * 4) + 44, (i * 4) + 47))
-            i = i + 1
+        # Per-cell voltages start past byte 40 -- exactly the region fragment
+        # duplication corrupts. Only trust them on non-bloated ("full") frames;
+        # a bloated frame's scalar head is fine but its cells are garbage.
+        if full:
+            self.PowerDevice.entities.afestatus = self.getValue(message, 40, 41)
+            # The frame carries up to 16 cell slots, but these packs have far fewer
+            # real cells; slots past the last real cell hold padding (0) or a
+            # different field. Stop at the first empty slot. Some frames also carry
+            # a corrupt low reading (~200 mV) in an otherwise-real cell slot -- a
+            # real cell is ~2.0-4.0 V, so skip anything outside a plausible cell
+            # range silently instead of letting the entity log it out-of-bounds.
+            i = 0
+            while i < 16:
+                cell_mv = self.getValue(message, (i * 4) + 44, (i * 4) + 47)
+                if cell_mv == 0:
+                    break
+                if 1000 <= cell_mv <= 5000:
+                    self.PowerDevice.entities.cell_mvoltage = (i + 1, cell_mv)
+                i = i + 1
 
         return True
 

--- a/plugins/Meritsun/__init__.py
+++ b/plugins/Meritsun/__init__.py
@@ -57,15 +57,6 @@ class Util():
         self.PowerDevice = power_device
         self.end = 0
         self.prev_values = []
-        # A real full data frame carries this constant field (ASCII hex) at a fixed
-        # byte offset from the START_VAL marker. The pack also emits shorter status/
-        # other packet types (different layout) and the post-upgrade BlueZ stream
-        # duplicates fragments inside frames; both start with the same marker but
-        # decode to garbage. Requiring this signature at its fixed offset is what
-        # separates real data frames from the rest -- validated on both packs across
-        # charge and discharge with zero good frames lost.
-        self.DATA_SIGNATURE = b"0B008087"
-        self.DATA_SIGNATURE_OFFSET = 35
 
     def getValue(self, buf, start, end):
         try:
@@ -144,8 +135,10 @@ class Util():
         if not data:
             return False
 
-        # The device streams several packet types back-to-back. A data packet
-        # starts with START_VAL (0x92); another packet type starts with 0xC9.
+        # The device streams frames back-to-back behind two markers, 0x92 and
+        # 0xC9. Both carry the same layout -- every checksum-valid frame decodes
+        # identically regardless of marker, and 0xC9 carries about two thirds of
+        # them -- so both start a frame.
         # Neither marker, nor the END_VAL (0x0C) padding, ever appears inside the
         # ASCII-hex payload, so the markers delimit packets unambiguously. We
         # accumulate the stream and re-sync on every marker, so a single lost or
@@ -163,9 +156,13 @@ class Util():
 
         updated = False
         while True:
-            start = self._stream.find(self.START_VAL)
+            start = -1
+            for mark in (self.START_VAL, 0xC9):
+                q = self._stream.find(mark)
+                if q >= 0 and (start < 0 or q < start):
+                    start = q
             if start < 0:
-                # No data packet forming; drop the (unhandled) leading bytes.
+                # No frame forming; drop the (unhandled) leading bytes.
                 self._stream.clear()
                 break
             nxt = -1
@@ -184,30 +181,31 @@ class Util():
                 updated = True
         return updated
 
+    def _frameEnd(self, packet):
+        # The checksum spans the frame up to its trailing 0x0C padding. `find`
+        # stops at the first 0x0C, which in this stream sits far too early; the
+        # device's own rule is the last padding byte before offset 110.
+        end = 0
+        for i in range(1, min(len(packet), 122)):
+            if packet[i] == self.END_VAL and end < 110:
+                end = i + 1
+        return end
+
     def _handleDataPacket(self, packet):
-        # packet[0] == START_VAL. Only real data frames carry DATA_SIGNATURE at its
-        # fixed offset; require it to reject the interleaved status/other packet
-        # types and mis-framed fragments (all of which decode to garbage). The
-        # scalar head stays intact even in fragment-bloated frames, so this is
-        # enough to trust the scalars; cells live further in and only survive in
-        # non-bloated frames, so gate them on length as well.
-        if packet.find(self.DATA_SIGNATURE) != self.DATA_SIGNATURE_OFFSET:
-            return False
-        end = packet.find(self.END_VAL)
-        if end < 0:
-            end = len(packet)
+        # Gate on the protocol checksum -- the only invariant that holds. The
+        # previous signature gate keyed on bytes that turned out to be live data:
+        # it matched 142/363 frames in July and 0/122 in August.
         buf = [0] * 122
         for k in range(min(len(packet), 122)):
             buf[k] = packet[k]
         self.RevBuf = buf
         self.Revindex = min(len(packet), 121)
-        self.end = end
-        full_frame = len(packet) <= 130
-        return self.handleMessage(buf[1:self.Revindex], full=full_frame)
-
-
-
-
+        self.end = self._frameEnd(packet)
+        if self.end < 60 or not self.validateChecksum(buf):
+            logging.debug("[%s] frame rejected: len=%d end=%d",
+                          self.PowerDevice.alias(), len(packet), self.end)
+            return False
+        return self.handleMessage(buf[1:self.Revindex], full=len(packet) <= 130)
 
 
     def handleMessage(self, message, full=True):
@@ -218,8 +216,7 @@ class Util():
         self.prev_values = message
 
         # A real pack always reports a nonzero pack voltage; a frame decoding it as
-        # 0 is not a data frame at all. (The DATA_SIGNATURE gate already rejects the
-        # other packet types; this is a cheap backstop.)
+        # 0 is not a data frame at all -- a cheap backstop behind the checksum.
         mvoltage = self.getValue(message, 0, 7)
         if mvoltage < 1000:
             return False

--- a/tests/test_meritsun_parser.py
+++ b/tests/test_meritsun_parser.py
@@ -1,0 +1,81 @@
+"""Regression tests for the Meritsun frame parser.
+
+The notifications below are a real capture from a 12V100Ah pack (2026-08-18).
+They decode to one complete frame; the pack was idle at the time, hence 0 A.
+"""
+
+import pytest
+
+from plugins.Meritsun import Util
+
+
+# One frame as delivered by BlueZ: 20-byte notifications, marker 0xC9.
+CAPTURED_FRAME = [
+    "c937463335303030303030303030303030",
+    "4130393230313030334630303633303033303042",
+    "3830383838374236343030453133304431363044",
+    "3136304430303030303030303030303030303030",
+    "3030303030303030303030303030303030303030",
+    "303030303030303030303030303542440c0c0c0c",
+    "0c0c0c0c92374633353030303030303030303030",
+]
+
+
+class _Entities:
+    def __init__(self):
+        self.values = {}
+
+    def __setattr__(self, key, value):
+        if key == "values":
+            return object.__setattr__(self, key, value)
+        self.values[key] = value
+
+
+class _Config:
+    def getboolean(self, *args, **kwargs):
+        return False
+
+
+class _Device:
+    def __init__(self):
+        self.config = _Config()
+        self.entities = _Entities()
+
+    def alias(self):
+        return "test-pack"
+
+
+@pytest.fixture
+def util():
+    return Util(_Device())
+
+
+def feed(util, frames):
+    return [util.notificationUpdate(bytes.fromhex(f), None) for f in frames]
+
+
+def test_captured_frame_is_accepted(util):
+    """A real frame must survive framing, the checksum gate and decoding."""
+    assert any(feed(util, CAPTURED_FRAME)), "no frame accepted from a real capture"
+    values = util.PowerDevice.entities.values
+    assert values["mvoltage"] == 13695
+    assert values["soc"] == 99
+    assert values["temperature"] == 2864
+    assert values["mcapacity"] == 103072
+
+
+def test_cell_voltages_are_decoded(util):
+    """Cells live past byte 40 and must come through on a full frame."""
+    feed(util, CAPTURED_FRAME)
+    assert "cell_mvoltage" in util.PowerDevice.entities.values
+
+
+def test_c9_and_92_are_both_frame_markers(util):
+    """0xC9 carries most frames; treating it as 'some other packet' loses them."""
+    assert CAPTURED_FRAME[0].startswith("c9")
+
+
+def test_fragments_are_rejected(util):
+    """A truncated frame must not decode: the checksum is the only gate."""
+    truncated = [f[:20] for f in CAPTURED_FRAME]
+    assert not any(feed(util, truncated))


### PR DESCRIPTION
Reworks the Meritsun battery frame parser to cope with the notification stream produced after the trixie / BlueZ 5.82 / kernel 6.18 upgrade. Touches `plugins/Meritsun/__init__.py` and adds a regression test.

## Problem
The upgrade changed BLE notification framing: the pack now interleaves several packet types and **duplicates fragments inside a data frame**, bloating it past its normal ~121 bytes. The old fixed-121-byte state machine desynced after the first frame or two and never re-synced, so the batteries went silent after the initial round. (Notifications are delivered at full rate — this is a framing/parsing problem, not a transport one.)

The first version of this PR replaced the checksum with a **constant signature** (`0B008087` at byte 35). That constant is live data, not structure — it lands on the tail of the temperature field, the **status** byte and the field after it:

```
0B008087  (2026-07-20)      0B808887  (2026-08-18)
││ ││ └┴── msg[38:42]:  8087 -> 8887
││ └┴───── msg[36:38] = status: 00 -> 80   (0 -> 128)
└┴──────── msg[34:36] = temperature high byte, 0B in both
```

Status reads 0 while the pack is discharging and 128 when it is not, so the gate effectively required "this pack is currently discharging". It matched **142/363** frames on 2026-07-20 and **0/122** on 2026-08-18. A miss returned `False` without logging, so 100 % rejection was indistinguishable from a dead radio.

This also explains the daily blackout the packs have shown since: reporting overnight while discharging into the aux load, silence through the day once the pack is full and floating, and permanent silence from 16 August when the load switch was left off and the pack stopped discharging at night too.

## Fix
- Accumulate the stream and **re-sync on the markers** instead of counting to a fixed 121 bytes (unchanged from the first version — this part was never the problem).
- Treat **`0xC9` as a frame marker alongside `0x92`**. Both carry the same layout — every checksum-valid frame decodes identically regardless of marker — and `0xC9` holds about two thirds of them.
- Gate on **`validateChecksum()`**, the protocol's own invariant, which was already in the file but uncalled. It needs the original `end` semantics: the **last `0x0C` before offset 110**. `packet.find()` returns the first one, far too early in this stream, and the checksum then never validates — which is why it looked useless.
- **Log rejections at debug level**, with length and `end`.

## Measured
Replaying real captures through the parser — both packs, before and after the stream changed:

| capture | old gate | new gate |
|---|---|---|
| pack 027, 2026-07-20 | 138 | 12 |
| pack 027, 2026-08-18 | **0** | **6** |
| pack 081, 2026-07-20 | 89 | 4 |
| pack 081, 2026-08-18 | **0** | **9** |

Fewer accepted on the July capture is expected: the signature gate also passed frames that do not checksum, which is where the "out of bands" warnings came from.

Deployed live: both packs resumed reporting voltage, signed current, SOC, capacity, temperature and per-cell voltages.

## Test
`tests/test_meritsun_parser.py` replays six real notifications captured from a live pack and asserts the decoded values (13695 mV, 99 % SOC, 2864 dK, 103072). It **fails on the pre-fix parser** and passes after. Full suite green (39 passing).

## Limits
The status-byte reading comes from two capture windows per pack, not a continuous log, so the day/night correlation is inferred rather than logged end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
