### PR TITLE
BLE connection reliability: serial coordinator, trust, backoff jitter

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -17,19 +17,27 @@ It is gatt-free and unit-testable: the actual gatt connect is supplied as
 `connect_fn`.
 """
 import logging
+import random
 import time
 
 _MAX_BACKOFF_EXP = 30   # clamp the exponent so backoff can't grow to a bigint
 
 
-def backoff_seconds(attempt, base=5.0, maximum=300.0):
-    """Exponential backoff for the Nth (1-based) consecutive failure, capped."""
+def backoff_seconds(attempt, base=10.0, maximum=300.0, jitter=5.0, rand=None):
+    """Exponential backoff for the Nth (1-based) consecutive failure, capped,
+    with a random +/- `jitter` seconds. The jitter spreads out otherwise-
+    synchronized retries across devices so their connect attempts don't all land
+    at the same moment and collide (e.g. first retry lands somewhere in ~5-15s,
+    not all at 10s). `rand` is injectable for deterministic tests."""
+    if rand is None:
+        rand = random.uniform
     attempt = min(max(attempt, 1), _MAX_BACKOFF_EXP)
-    return min(base * (2 ** (attempt - 1)), maximum)
+    delay = min(base * (2 ** (attempt - 1)), maximum)
+    return max(delay + rand(-jitter, jitter), 0.0)
 
 
-def maintain_device(name, connect_fn, stop_event, base_backoff=5.0,
-                    max_backoff=300.0, sleep=None):
+def maintain_device(name, connect_fn, stop_event, base_backoff=10.0,
+                    max_backoff=300.0, jitter=5.0, rand=None, sleep=None):
     """Keep one device connected until stop_event is set.
 
     `connect_fn()` performs one full connect attempt and BLOCKS until the device
@@ -56,6 +64,6 @@ def maintain_device(name, connect_fn, stop_event, base_backoff=5.0,
             attempt = 0                      # had a good connection — retry promptly
             continue
         attempt += 1
-        delay = backoff_seconds(attempt, base_backoff, max_backoff)
-        logging.info("[%s] connect failed; retrying in %ss", name, delay)
+        delay = backoff_seconds(attempt, base_backoff, max_backoff, jitter, rand)
+        logging.info("[%s] connect failed; retrying in %.1fs", name, delay)
         sleep(delay)

--- a/connection.py
+++ b/connection.py
@@ -1,117 +1,61 @@
-"""Serialized, patient BLE connection coordinator.
+"""Per-device BLE connection maintenance.
 
-Root cause (found on real hardware): BLE links connect but then abort during
-GATT service resolution (`le-connection-abort-by-local`). It is transient and
-succeeds on retry, but the old code fired every device's connect and every
-10-second reconnect concurrently, so attempts collided and never let the
-devices/adapter settle.
+Root cause (found on real hardware): with multiple BLE devices, a link connects
+but often aborts during GATT service resolution; it is transient and succeeds on
+retry. The behaviour that actually works on the hardware is the *old* code's:
+connect every device concurrently (one thread each) straight after discovery,
+and let the transient aborts be ridden out by retrying — strict serialization
+made it worse, not better.
 
-This module owns the *policy* — which device to (re)connect next, one at a time,
-with exponential backoff — and is deliberately gatt-free so it is unit-testable
-without Bluetooth. The actual connect is performed by a caller-supplied
-`connect_fn` (see run_connection_loop), which does the gatt connect and blocks
-until the device resolves services or the attempt fails/times out.
+This module provides that: one `maintain_device` loop per device (run in its own
+thread, so connects happen concurrently), with exponential backoff between failed
+attempts. Trusting the device (done by the caller via SolarDevice.set_trusted)
+keeps BlueZ from removing it as a 'temporary' device after ~30s and lets BlueZ
+auto-reconnect it.
+
+It is gatt-free and unit-testable: the actual gatt connect is supplied as
+`connect_fn`.
 """
 import logging
-import threading
 import time
 
+_MAX_BACKOFF_EXP = 30   # clamp the exponent so backoff can't grow to a bigint
 
-class ConnectionCoordinator:
-    """Tracks per-device connection state and decides what to connect next.
 
-    Only ever hands out one device at a time via next_due(); the caller connects
-    it (blocking) and reports the outcome to record_result(). Failures back off
-    exponentially so a flapping device does not get hammered.
+def backoff_seconds(attempt, base=5.0, maximum=300.0):
+    """Exponential backoff for the Nth (1-based) consecutive failure, capped."""
+    attempt = min(max(attempt, 1), _MAX_BACKOFF_EXP)
+    return min(base * (2 ** (attempt - 1)), maximum)
 
-    Thread-safe: the connection loop calls next_due()/record_result() on one
-    thread while mark_disconnected() is called from the gatt callback thread, so
-    every _state access is guarded by a lock.
+
+def maintain_device(name, connect_fn, stop_event, base_backoff=5.0,
+                    max_backoff=300.0, sleep=None):
+    """Keep one device connected until stop_event is set.
+
+    `connect_fn()` performs one full connect attempt and BLOCKS until the device
+    is no longer connected. It returns True if the device had connected (and has
+    since dropped) or False if the attempt never connected. After a good
+    connection we retry promptly; after a failed attempt we back off
+    exponentially so a device that is off/out of range is not hammered.
+
+    `sleep` defaults to `stop_event.wait` so backoff is interruptible on
+    shutdown; tests inject their own.
     """
-
-    _MAX_ATTEMPTS_FOR_BACKOFF = 30  # clamp the exponent so backoff can't grow to a bigint
-
-    def __init__(self, base_backoff=5.0, max_backoff=300.0, get_time=time.time):
-        self._get_time = get_time
-        self.base_backoff = base_backoff
-        self.max_backoff = max_backoff
-        self._lock = threading.Lock()
-        self._state = {}  # key -> {"connected": bool, "attempts": int, "next_attempt": float}
-
-    def add(self, key):
-        """Register a device to be kept connected."""
-        with self._lock:
-            self._state.setdefault(key, {"connected": False, "attempts": 0, "next_attempt": 0.0})
-
-    def _backoff(self, attempts):
-        attempts = min(attempts, self._MAX_ATTEMPTS_FOR_BACKOFF)
-        return min(self.base_backoff * (2 ** (attempts - 1)), self.max_backoff)
-
-    def next_due(self):
-        """The key of the next disconnected device whose backoff has elapsed, or
-        None. Earliest-due first, then by key for determinism."""
-        now = self._get_time()
-        with self._lock:
-            due = [(s["next_attempt"], k) for k, s in self._state.items()
-                   if not s["connected"] and s["next_attempt"] <= now]
-        if not due:
-            return None
-        due.sort()
-        return due[0][1]
-
-    def record_result(self, key, success):
-        """Report the outcome of a connection attempt for `key`."""
-        with self._lock:
-            s = self._state[key]
-            if success:
-                s["connected"] = True
-                s["attempts"] = 0
-                s["next_attempt"] = 0.0
-            else:
-                s["attempts"] += 1
-                s["next_attempt"] = self._get_time() + self._backoff(s["attempts"])
-
-    def mark_disconnected(self, key):
-        """A previously-connected device dropped; queue it for reconnect after a
-        short settle delay (not immediately, to avoid hammering a flapper)."""
-        with self._lock:
-            s = self._state.get(key)
-            if s is None:
-                return
-            s["connected"] = False
-            s["attempts"] = 0
-            s["next_attempt"] = self._get_time() + self.base_backoff
-
-    def connected_count(self):
-        with self._lock:
-            return sum(1 for s in self._state.values() if s["connected"])
-
-    def all_connected(self):
-        with self._lock:
-            return all(s["connected"] for s in self._state.values()) if self._state else True
-
-
-def run_connection_loop(coordinator, connect_fn, stop_event, get_time=time.time,
-                        sleep=time.sleep, on_idle=None, idle_sleep=1.0):
-    """Serially connect due devices until stop_event is set.
-
-    connect_fn(key) -> bool performs the actual (blocking) gatt connect and
-    returns True if the device resolved services. Because it blocks, only ONE
-    connection attempt is ever in flight — that serialization is the whole point.
-    on_idle() is called whenever nothing is due (useful to check for completion).
-    """
+    if sleep is None:
+        sleep = stop_event.wait
+    attempt = 0
     while not stop_event.is_set():
-        key = coordinator.next_due()
-        if key is None:
-            if on_idle is not None:
-                on_idle()
-            if stop_event.is_set():
-                break
-            sleep(idle_sleep)
-            continue
         try:
-            success = connect_fn(key)
+            was_connected = connect_fn()
         except Exception as e:
-            logging.error("connect_fn(%s) raised: %r", key, e)
-            success = False
-        coordinator.record_result(key, success)
+            logging.error("[%s] connection loop error: %r", name, e)
+            was_connected = False
+        if stop_event.is_set():
+            break
+        if was_connected:
+            attempt = 0                      # had a good connection — retry promptly
+            continue
+        attempt += 1
+        delay = backoff_seconds(attempt, base_backoff, max_backoff)
+        logging.info("[%s] connect failed; retrying in %ss", name, delay)
+        sleep(delay)

--- a/connection.py
+++ b/connection.py
@@ -13,6 +13,7 @@ without Bluetooth. The actual connect is performed by a caller-supplied
 until the device resolves services or the attempt fails/times out.
 """
 import logging
+import threading
 import time
 
 
@@ -22,27 +23,37 @@ class ConnectionCoordinator:
     Only ever hands out one device at a time via next_due(); the caller connects
     it (blocking) and reports the outcome to record_result(). Failures back off
     exponentially so a flapping device does not get hammered.
+
+    Thread-safe: the connection loop calls next_due()/record_result() on one
+    thread while mark_disconnected() is called from the gatt callback thread, so
+    every _state access is guarded by a lock.
     """
+
+    _MAX_ATTEMPTS_FOR_BACKOFF = 30  # clamp the exponent so backoff can't grow to a bigint
 
     def __init__(self, base_backoff=5.0, max_backoff=300.0, get_time=time.time):
         self._get_time = get_time
         self.base_backoff = base_backoff
         self.max_backoff = max_backoff
+        self._lock = threading.Lock()
         self._state = {}  # key -> {"connected": bool, "attempts": int, "next_attempt": float}
 
     def add(self, key):
         """Register a device to be kept connected."""
-        self._state.setdefault(key, {"connected": False, "attempts": 0, "next_attempt": 0.0})
+        with self._lock:
+            self._state.setdefault(key, {"connected": False, "attempts": 0, "next_attempt": 0.0})
 
     def _backoff(self, attempts):
+        attempts = min(attempts, self._MAX_ATTEMPTS_FOR_BACKOFF)
         return min(self.base_backoff * (2 ** (attempts - 1)), self.max_backoff)
 
     def next_due(self):
         """The key of the next disconnected device whose backoff has elapsed, or
         None. Earliest-due first, then by key for determinism."""
         now = self._get_time()
-        due = [(s["next_attempt"], k) for k, s in self._state.items()
-               if not s["connected"] and s["next_attempt"] <= now]
+        with self._lock:
+            due = [(s["next_attempt"], k) for k, s in self._state.items()
+                   if not s["connected"] and s["next_attempt"] <= now]
         if not due:
             return None
         due.sort()
@@ -50,30 +61,34 @@ class ConnectionCoordinator:
 
     def record_result(self, key, success):
         """Report the outcome of a connection attempt for `key`."""
-        s = self._state[key]
-        if success:
-            s["connected"] = True
-            s["attempts"] = 0
-            s["next_attempt"] = 0.0
-        else:
-            s["attempts"] += 1
-            s["next_attempt"] = self._get_time() + self._backoff(s["attempts"])
+        with self._lock:
+            s = self._state[key]
+            if success:
+                s["connected"] = True
+                s["attempts"] = 0
+                s["next_attempt"] = 0.0
+            else:
+                s["attempts"] += 1
+                s["next_attempt"] = self._get_time() + self._backoff(s["attempts"])
 
     def mark_disconnected(self, key):
         """A previously-connected device dropped; queue it for reconnect after a
         short settle delay (not immediately, to avoid hammering a flapper)."""
-        s = self._state.get(key)
-        if s is None:
-            return
-        s["connected"] = False
-        s["attempts"] = 0
-        s["next_attempt"] = self._get_time() + self.base_backoff
+        with self._lock:
+            s = self._state.get(key)
+            if s is None:
+                return
+            s["connected"] = False
+            s["attempts"] = 0
+            s["next_attempt"] = self._get_time() + self.base_backoff
 
     def connected_count(self):
-        return sum(1 for s in self._state.values() if s["connected"])
+        with self._lock:
+            return sum(1 for s in self._state.values() if s["connected"])
 
     def all_connected(self):
-        return all(s["connected"] for s in self._state.values()) if self._state else True
+        with self._lock:
+            return all(s["connected"] for s in self._state.values()) if self._state else True
 
 
 def run_connection_loop(coordinator, connect_fn, stop_event, get_time=time.time,

--- a/connection.py
+++ b/connection.py
@@ -1,0 +1,102 @@
+"""Serialized, patient BLE connection coordinator.
+
+Root cause (found on real hardware): BLE links connect but then abort during
+GATT service resolution (`le-connection-abort-by-local`). It is transient and
+succeeds on retry, but the old code fired every device's connect and every
+10-second reconnect concurrently, so attempts collided and never let the
+devices/adapter settle.
+
+This module owns the *policy* — which device to (re)connect next, one at a time,
+with exponential backoff — and is deliberately gatt-free so it is unit-testable
+without Bluetooth. The actual connect is performed by a caller-supplied
+`connect_fn` (see run_connection_loop), which does the gatt connect and blocks
+until the device resolves services or the attempt fails/times out.
+"""
+import logging
+import time
+
+
+class ConnectionCoordinator:
+    """Tracks per-device connection state and decides what to connect next.
+
+    Only ever hands out one device at a time via next_due(); the caller connects
+    it (blocking) and reports the outcome to record_result(). Failures back off
+    exponentially so a flapping device does not get hammered.
+    """
+
+    def __init__(self, base_backoff=5.0, max_backoff=300.0, get_time=time.time):
+        self._get_time = get_time
+        self.base_backoff = base_backoff
+        self.max_backoff = max_backoff
+        self._state = {}  # key -> {"connected": bool, "attempts": int, "next_attempt": float}
+
+    def add(self, key):
+        """Register a device to be kept connected."""
+        self._state.setdefault(key, {"connected": False, "attempts": 0, "next_attempt": 0.0})
+
+    def _backoff(self, attempts):
+        return min(self.base_backoff * (2 ** (attempts - 1)), self.max_backoff)
+
+    def next_due(self):
+        """The key of the next disconnected device whose backoff has elapsed, or
+        None. Earliest-due first, then by key for determinism."""
+        now = self._get_time()
+        due = [(s["next_attempt"], k) for k, s in self._state.items()
+               if not s["connected"] and s["next_attempt"] <= now]
+        if not due:
+            return None
+        due.sort()
+        return due[0][1]
+
+    def record_result(self, key, success):
+        """Report the outcome of a connection attempt for `key`."""
+        s = self._state[key]
+        if success:
+            s["connected"] = True
+            s["attempts"] = 0
+            s["next_attempt"] = 0.0
+        else:
+            s["attempts"] += 1
+            s["next_attempt"] = self._get_time() + self._backoff(s["attempts"])
+
+    def mark_disconnected(self, key):
+        """A previously-connected device dropped; queue it for reconnect after a
+        short settle delay (not immediately, to avoid hammering a flapper)."""
+        s = self._state.get(key)
+        if s is None:
+            return
+        s["connected"] = False
+        s["attempts"] = 0
+        s["next_attempt"] = self._get_time() + self.base_backoff
+
+    def connected_count(self):
+        return sum(1 for s in self._state.values() if s["connected"])
+
+    def all_connected(self):
+        return all(s["connected"] for s in self._state.values()) if self._state else True
+
+
+def run_connection_loop(coordinator, connect_fn, stop_event, get_time=time.time,
+                        sleep=time.sleep, on_idle=None, idle_sleep=1.0):
+    """Serially connect due devices until stop_event is set.
+
+    connect_fn(key) -> bool performs the actual (blocking) gatt connect and
+    returns True if the device resolved services. Because it blocks, only ONE
+    connection attempt is ever in flight — that serialization is the whole point.
+    on_idle() is called whenever nothing is due (useful to check for completion).
+    """
+    while not stop_event.is_set():
+        key = coordinator.next_due()
+        if key is None:
+            if on_idle is not None:
+                on_idle()
+            if stop_event.is_set():
+                break
+            sleep(idle_sleep)
+            continue
+        try:
+            success = connect_fn(key)
+        except Exception as e:
+            logging.error("connect_fn(%s) raised: %r", key, e)
+            success = False
+        coordinator.record_result(key, success)

--- a/monitor_app.py
+++ b/monitor_app.py
@@ -23,6 +23,8 @@ from connection import ConnectionCoordinator, run_connection_loop
 DISCOVERY_WINDOW = 5     # stop discovery after this many seconds with no new devices
 DISCOVERY_MAX_WAIT = 15  # hard cap on discovery duration (seconds)
 CONNECT_TIMEOUT = 40.0   # per-attempt wait for a device to resolve services
+DISCOVER_REFRESH = 3.0   # brief re-scan before a connect so BlueZ still knows the device
+DRAIN_TIMEOUT = 4.0      # wait for a failed device to fully tear down before the next attempt
 
 
 class ConfigError(Exception):
@@ -167,10 +169,35 @@ def main(argv=None):
     loop_thread = threading.Thread(target=device_manager.run, name="gatt-mainloop", daemon=True)
     loop_thread.start()
 
+    def _refresh_discovery():
+        """Briefly re-scan so BlueZ still knows the device. It forgets devices it
+        has not seen recently, which makes a later connect fail with 'Device does
+        not exist'. Serialized connects are spaced out, so without this the
+        startup discovery cache expires between attempts. The scan is stopped
+        before connecting (scanning + connecting collide)."""
+        try:
+            device_manager.start_discovery()
+            time.sleep(DISCOVER_REFRESH)
+            device_manager.stop_discovery()
+            time.sleep(1)   # let discovery fully stop before we connect
+        except Exception as e:
+            logging.debug("Discovery refresh failed: %s", e)
+
+    def _drain(device):
+        """Fully disconnect a failed device and wait for teardown, so a late
+        callback from this attempt cannot bleed into the next one."""
+        device._disconnect_event.clear()
+        try:
+            device.disconnect()
+        except Exception:
+            pass
+        device._disconnect_event.wait(DRAIN_TIMEOUT)
+
     def connect_fn(key):
         """Connect one device and block until it resolves services, fails, or
         times out. Serialized by the connection loop — only one at a time."""
         device = devices[key]
+        _refresh_discovery()
         device._connect_ok = False
         device._connect_event.clear()
         logging.info("[%s] Connecting to %s", key, device.mac_address)
@@ -178,15 +205,14 @@ def main(argv=None):
             device.connect()
         except Exception as e:
             logging.error("[%s] connect() raised: %s", key, e)
+            _drain(device)
             return False
-        if not device._connect_event.wait(CONNECT_TIMEOUT):
-            logging.warning("[%s] connect timed out after %ss", key, CONNECT_TIMEOUT)
-            try:
-                device.disconnect()
-            except Exception:
-                pass
-            return False
-        return device._connect_ok
+        ok = device._connect_event.wait(CONNECT_TIMEOUT) and device._connect_ok
+        if not ok:
+            if not device._connect_event.is_set():
+                logging.warning("[%s] connect timed out after %ss", key, CONNECT_TIMEOUT)
+            _drain(device)
+        return ok
 
     conn_thread = threading.Thread(
         target=run_connection_loop, args=(coordinator, connect_fn, stop_event),
@@ -199,6 +225,7 @@ def main(argv=None):
 
     stop_event.set()
     device_manager.stop()
+    conn_thread.join(timeout=2)   # let the connection loop finish its current step
     for device in devices.values():
         try:
             device.disconnect()

--- a/monitor_app.py
+++ b/monitor_app.py
@@ -18,14 +18,14 @@ from solardevice import SolarDeviceManager, SolarDevice
 from datalogger import DataLogger
 import duallog
 from supervisor import run_logger, LivenessTracker, supervise
-from connection import ConnectionCoordinator, run_connection_loop
+from connection import maintain_device
 
 DISCOVERY_WINDOW = 5     # stop discovery after this many seconds with no new devices
 DISCOVERY_MAX_WAIT = 15  # hard cap on discovery duration (seconds)
 CONNECT_TIMEOUT = 40.0   # per-attempt wait for a device to resolve services
-DISCOVER_REFRESH = 3.0   # brief re-scan before a connect so BlueZ still knows the device
-DRAIN_TIMEOUT = 4.0      # wait for a failed device to fully tear down before the next attempt
-REDISCOVER_INTERVAL = 60.0  # how often to re-scan for configured devices that appear after startup
+CONNECT_STAGGER = 1.0    # delay between starting each device's connect (like the old code)
+HOLD_POLL = 5.0          # while connected, how often to check the device is still up
+REDISCOVER_INTERVAL = 120.0  # how often to re-scan for configured devices that appear after startup
 
 
 class ConfigError(Exception):
@@ -127,10 +127,6 @@ def main(argv=None):
 
     run_discovery(device_manager)
 
-    # The connection coordinator connects devices one at a time (see
-    # connection.py) instead of firing every connect concurrently — concurrent
-    # attempts collide and abort BLE service resolution.
-    coordinator = ConnectionCoordinator()
     # All configured devices (section -> mac), whether or not discovered yet.
     configured = {}
     for section in config.sections():
@@ -140,22 +136,45 @@ def main(argv=None):
             configured[section] = mac.lower()
     devices = {}   # section -> SolarDevice, once registered
 
-    def _refresh_discovery():
-        """Briefly re-scan so BlueZ still knows the devices (it forgets ones it
-        has not seen recently, causing 'Device does not exist' on connect) and so
-        devices that start advertising after startup can be found. Stopped before
-        any connect — scanning and connecting collide."""
-        try:
-            device_manager.start_discovery()
-            time.sleep(DISCOVER_REFRESH)
-            device_manager.stop_discovery()
-            time.sleep(1)   # let discovery fully stop before we connect
-        except Exception as e:
-            logging.debug("Discovery refresh failed: %s", e)
+    def _handle_signal(signum, _frame):
+        logging.info("Received signal %s; shutting down.", signum)
+        stop_event.set()
+        device_manager.stop()
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    # The gatt main loop must run so connection callbacks (services_resolved,
+    # connect_failed, disconnect_succeeded) fire while we connect.
+    loop_thread = threading.Thread(target=device_manager.run, name="gatt-mainloop", daemon=True)
+    loop_thread.start()
+
+    def _make_connect_fn(device):
+        """One connect attempt for maintain_device: connect, and if it resolves,
+        hold until it drops. Returns True if it had connected (and has now
+        dropped), False if it never connected."""
+        def connect_once():
+            device._connect_ok = False
+            device._connect_event.clear()
+            logging.info("[%s] Connecting to %s", device.logger_name, device.mac_address)
+            try:
+                device.connect()
+            except Exception as e:
+                logging.error("[%s] connect() raised: %s", device.logger_name, e)
+                return False
+            if not (device._connect_event.wait(CONNECT_TIMEOUT) and device._connect_ok):
+                return False
+            # Connected and resolved — hold the connection until it drops.
+            device._disconnect_event.clear()
+            while not stop_event.is_set():
+                if device._disconnect_event.wait(HOLD_POLL):
+                    break
+            return True
+        return connect_once
 
     def _register(section):
-        """Create and register a SolarDevice for a configured section whose MAC is
-        currently discovered. Returns True if newly registered."""
+        """Create + trust a SolarDevice for a discovered configured section and
+        start its maintenance thread. Returns True if newly registered."""
         if section in devices:
             return False
         mac = configured[section]
@@ -172,100 +191,47 @@ def main(argv=None):
         # Trust it so BlueZ keeps it (no ~30s temporary-device removal) and can
         # auto-reconnect it — the device is discovered here, so its object exists.
         device.set_trusted()
-        device.on_disconnect = (lambda key=section: coordinator.mark_disconnected(key))
         devices[section] = device
-        coordinator.add(section)
         liveness.expect(section)
+        threading.Thread(target=maintain_device,
+                         args=(section, _make_connect_fn(device), stop_event),
+                         name="connect-%s" % section, daemon=True).start()
         logging.info("Registered device [%s] %s", section, mac)
         return True
 
-    # Register the configured devices found during the startup scan.
+    # Start each discovered device's connect concurrently, staggered like the old
+    # code — that is what the hardware actually connects reliably; strict
+    # serialization was worse.
     for section in configured:
-        _register(section)
+        if _register(section):
+            time.sleep(CONNECT_STAGGER)
 
     if not devices:
         logging.error("No configured devices were discovered; exiting for restart.")
         stop_event.set()
         return 1
 
-    def _handle_signal(signum, _frame):
-        logging.info("Received signal %s; shutting down.", signum)
-        stop_event.set()
-        device_manager.stop()
+    def _late_discovery_loop():
+        """Occasionally re-scan for configured devices that started advertising
+        after startup (e.g. a battery whose BMS was reset) and start maintaining
+        them. Trusted devices persist, so this only runs while something is still
+        missing — and it is the one place we scan while connections may be held,
+        so it is infrequent."""
+        while not stop_event.wait(REDISCOVER_INTERVAL):
+            missing = [s for s in configured if s not in devices]
+            if not missing:
+                continue
+            logging.info("Re-discovering for late devices: %s", ", ".join(sorted(missing)))
+            try:
+                device_manager.start_discovery()
+                stop_event.wait(DISCOVERY_WINDOW)
+                device_manager.stop_discovery()
+            except Exception as e:
+                logging.debug("Late discovery scan failed: %s", e)
+            for section in missing:
+                _register(section)
 
-    signal.signal(signal.SIGTERM, _handle_signal)
-    signal.signal(signal.SIGINT, _handle_signal)
-
-    # The gatt main loop must run so connection callbacks (services_resolved,
-    # connect_failed, disconnect_succeeded) fire while we connect.
-    loop_thread = threading.Thread(target=device_manager.run, name="gatt-mainloop", daemon=True)
-    loop_thread.start()
-
-    def _drain(device):
-        """Fully disconnect a failed device and wait for teardown, so a late
-        callback from this attempt cannot bleed into the next one."""
-        device._disconnect_event.clear()
-        try:
-            device.disconnect()
-        except Exception:
-            pass
-        device._disconnect_event.wait(DRAIN_TIMEOUT)
-
-    def connect_fn(key):
-        """Connect one device and block until it resolves services, fails, or
-        times out. Serialized by the connection loop — only one at a time.
-
-        Deliberately does NOT scan here: scanning immediately before a connect
-        collides with it and aborts service resolution (this is what the old
-        concurrent code got right — it connected straight from the startup scan's
-        still-fresh cache). Cache freshness is kept up by _on_idle instead."""
-        device = devices[key]
-        device._connect_ok = False
-        device._connect_event.clear()
-        logging.info("[%s] Connecting to %s", key, device.mac_address)
-        try:
-            device.connect()
-        except Exception as e:
-            logging.error("[%s] connect() raised: %s", key, e)
-            _drain(device)
-            return False
-        ok = device._connect_event.wait(CONNECT_TIMEOUT) and device._connect_ok
-        if not ok:
-            if not device._connect_event.is_set():
-                logging.warning("[%s] connect timed out after %ss", key, CONNECT_TIMEOUT)
-            _drain(device)
-        return ok
-
-    rediscover = {"last": 0.0}
-
-    def _on_idle():
-        """Periodically re-scan while anything is not connected. This keeps
-        BlueZ's device cache fresh for reconnects (it forgets devices it has not
-        seen, which otherwise makes a later connect fail with 'Device does not
-        exist') and registers configured devices that started advertising after
-        startup (e.g. a battery whose BMS was reset). It runs here, between
-        connects, NOT before each connect — scanning right before a connect
-        collides with it and aborts service resolution."""
-        missing = [s for s in configured if s not in devices]
-        if not missing and coordinator.all_connected():
-            return   # everything registered and connected — no need to scan
-        now = time.time()
-        if now - rediscover["last"] < REDISCOVER_INTERVAL:
-            return
-        rediscover["last"] = now
-        if missing:
-            logging.info("Re-discovering (late devices / cache refresh): %s", ", ".join(sorted(missing)))
-        else:
-            logging.debug("Re-discovering to refresh the cache for disconnected devices")
-        _refresh_discovery()
-        for section in missing:
-            _register(section)
-
-    conn_thread = threading.Thread(
-        target=run_connection_loop, args=(coordinator, connect_fn, stop_event),
-        kwargs={"on_idle": _on_idle},
-        name="connection-loop", daemon=True)
-    conn_thread.start()
+    threading.Thread(target=_late_discovery_loop, name="late-discovery", daemon=True).start()
 
     logging.info("Supervising; terminate with Ctrl+C or SIGTERM")
     exit_code = supervise(device_manager, logger_future, liveness, stop_event,
@@ -273,7 +239,6 @@ def main(argv=None):
 
     stop_event.set()
     device_manager.stop()
-    conn_thread.join(timeout=2)   # let the connection loop finish its current step
     for device in devices.values():
         try:
             device.disconnect()

--- a/monitor_app.py
+++ b/monitor_app.py
@@ -169,6 +169,9 @@ def main(argv=None):
         except Exception as e:
             logging.error("Could not set up device [%s]: %s", section, e)
             return False
+        # Trust it so BlueZ keeps it (no ~30s temporary-device removal) and can
+        # auto-reconnect it — the device is discovered here, so its object exists.
+        device.set_trusted()
         device.on_disconnect = (lambda key=section: coordinator.mark_disconnected(key))
         devices[section] = device
         coordinator.add(section)

--- a/monitor_app.py
+++ b/monitor_app.py
@@ -25,6 +25,7 @@ DISCOVERY_MAX_WAIT = 15  # hard cap on discovery duration (seconds)
 CONNECT_TIMEOUT = 40.0   # per-attempt wait for a device to resolve services
 DISCOVER_REFRESH = 3.0   # brief re-scan before a connect so BlueZ still knows the device
 DRAIN_TIMEOUT = 4.0      # wait for a failed device to fully tear down before the next attempt
+REDISCOVER_INTERVAL = 60.0  # how often to re-scan for configured devices that appear after startup
 
 
 class ConfigError(Exception):
@@ -126,30 +127,58 @@ def main(argv=None):
 
     run_discovery(device_manager)
 
-    # Build a SolarDevice per configured device that was discovered, and register
-    # it with the connection coordinator. The coordinator connects them one at a
-    # time (see connection.py) instead of firing every connect concurrently —
-    # concurrent attempts collide and abort BLE service resolution.
+    # The connection coordinator connects devices one at a time (see
+    # connection.py) instead of firing every connect concurrently — concurrent
+    # attempts collide and abort BLE service resolution.
     coordinator = ConnectionCoordinator()
-    devices = {}
-    for dev in device_manager.devices():
-        logging.debug("Processing device {} {}".format(dev.mac_address, dev.alias()))
-        for section in config.sections():
-            if config.get(section, "mac", fallback=None) and config.get(section, "type", fallback=None):
-                mac = config.get(section, "mac").lower()
-                if dev.mac_address.lower() == mac:
-                    try:
-                        device = SolarDevice(mac_address=dev.mac_address, manager=device_manager,
-                                             logger_name=section, config=config,
-                                             datalogger=datalogger, queue=pipeline)
-                    except Exception as e:
-                        logging.error("Could not set up device [%s]: %s", section, e)
-                        break
-                    device.on_disconnect = (lambda key=section: coordinator.mark_disconnected(key))
-                    devices[section] = device
-                    coordinator.add(section)
-                    liveness.expect(section)
-                    break
+    # All configured devices (section -> mac), whether or not discovered yet.
+    configured = {}
+    for section in config.sections():
+        mac = config.get(section, "mac", fallback=None)
+        dtype = config.get(section, "type", fallback=None)
+        if mac and dtype:
+            configured[section] = mac.lower()
+    devices = {}   # section -> SolarDevice, once registered
+
+    def _refresh_discovery():
+        """Briefly re-scan so BlueZ still knows the devices (it forgets ones it
+        has not seen recently, causing 'Device does not exist' on connect) and so
+        devices that start advertising after startup can be found. Stopped before
+        any connect — scanning and connecting collide."""
+        try:
+            device_manager.start_discovery()
+            time.sleep(DISCOVER_REFRESH)
+            device_manager.stop_discovery()
+            time.sleep(1)   # let discovery fully stop before we connect
+        except Exception as e:
+            logging.debug("Discovery refresh failed: %s", e)
+
+    def _register(section):
+        """Create and register a SolarDevice for a configured section whose MAC is
+        currently discovered. Returns True if newly registered."""
+        if section in devices:
+            return False
+        mac = configured[section]
+        disc = next((d for d in device_manager.devices() if d.mac_address.lower() == mac), None)
+        if disc is None:
+            return False
+        try:
+            device = SolarDevice(mac_address=disc.mac_address, manager=device_manager,
+                                 logger_name=section, config=config,
+                                 datalogger=datalogger, queue=pipeline)
+        except Exception as e:
+            logging.error("Could not set up device [%s]: %s", section, e)
+            return False
+        device.on_disconnect = (lambda key=section: coordinator.mark_disconnected(key))
+        devices[section] = device
+        coordinator.add(section)
+        liveness.expect(section)
+        logging.info("Registered device [%s] %s", section, mac)
+        return True
+
+    # Register the configured devices found during the startup scan.
+    for section in configured:
+        _register(section)
 
     if not devices:
         logging.error("No configured devices were discovered; exiting for restart.")
@@ -168,20 +197,6 @@ def main(argv=None):
     # connect_failed, disconnect_succeeded) fire while we connect.
     loop_thread = threading.Thread(target=device_manager.run, name="gatt-mainloop", daemon=True)
     loop_thread.start()
-
-    def _refresh_discovery():
-        """Briefly re-scan so BlueZ still knows the device. It forgets devices it
-        has not seen recently, which makes a later connect fail with 'Device does
-        not exist'. Serialized connects are spaced out, so without this the
-        startup discovery cache expires between attempts. The scan is stopped
-        before connecting (scanning + connecting collide)."""
-        try:
-            device_manager.start_discovery()
-            time.sleep(DISCOVER_REFRESH)
-            device_manager.stop_discovery()
-            time.sleep(1)   # let discovery fully stop before we connect
-        except Exception as e:
-            logging.debug("Discovery refresh failed: %s", e)
 
     def _drain(device):
         """Fully disconnect a failed device and wait for teardown, so a late
@@ -214,8 +229,27 @@ def main(argv=None):
             _drain(device)
         return ok
 
+    rediscover = {"last": 0.0}
+
+    def _on_idle():
+        """When the loop has nothing due, periodically re-scan for configured
+        devices that started advertising after startup (e.g. a battery whose BMS
+        was reset) and register them so the loop begins connecting them."""
+        missing = [s for s in configured if s not in devices]
+        if not missing:
+            return
+        now = time.time()
+        if now - rediscover["last"] < REDISCOVER_INTERVAL:
+            return
+        rediscover["last"] = now
+        logging.info("Re-discovering for late devices: %s", ", ".join(sorted(missing)))
+        _refresh_discovery()
+        for section in missing:
+            _register(section)
+
     conn_thread = threading.Thread(
         target=run_connection_loop, args=(coordinator, connect_fn, stop_event),
+        kwargs={"on_idle": _on_idle},
         name="connection-loop", daemon=True)
     conn_thread.start()
 

--- a/monitor_app.py
+++ b/monitor_app.py
@@ -18,9 +18,11 @@ from solardevice import SolarDeviceManager, SolarDevice
 from datalogger import DataLogger
 import duallog
 from supervisor import run_logger, LivenessTracker, supervise
+from connection import ConnectionCoordinator, run_connection_loop
 
 DISCOVERY_WINDOW = 5     # stop discovery after this many seconds with no new devices
 DISCOVERY_MAX_WAIT = 15  # hard cap on discovery duration (seconds)
+CONNECT_TIMEOUT = 40.0   # per-attempt wait for a device to resolve services
 
 
 class ConfigError(Exception):
@@ -84,18 +86,6 @@ def run_discovery(device_manager, max_wait=DISCOVERY_MAX_WAIT, window=DISCOVERY_
     logging.info("Found {} BLE-devices".format(len(device_manager.devices())))
 
 
-def threaded_poller(dev, device_manager, logger_name, config, datalogger, queue):
-    logging.info("Trying to connect to {}...".format(dev.mac_address))
-    try:
-        device = SolarDevice(mac_address=dev.mac_address, manager=device_manager,
-                             logger_name=logger_name, config=config,
-                             datalogger=datalogger, queue=queue)
-    except Exception as e:
-        logging.error(e)
-        return
-    device.connect()
-
-
 def main(argv=None):
     args = parse_args(argv)
     ini_file = args.ini or "solar-monitor.ini"
@@ -134,21 +124,32 @@ def main(argv=None):
 
     run_discovery(device_manager)
 
-    matched = 0
+    # Build a SolarDevice per configured device that was discovered, and register
+    # it with the connection coordinator. The coordinator connects them one at a
+    # time (see connection.py) instead of firing every connect concurrently —
+    # concurrent attempts collide and abort BLE service resolution.
+    coordinator = ConnectionCoordinator()
+    devices = {}
     for dev in device_manager.devices():
         logging.debug("Processing device {} {}".format(dev.mac_address, dev.alias()))
         for section in config.sections():
             if config.get(section, "mac", fallback=None) and config.get(section, "type", fallback=None):
                 mac = config.get(section, "mac").lower()
                 if dev.mac_address.lower() == mac:
-                    executor.submit(threaded_poller, dev, device_manager, section, config, datalogger, pipeline)
+                    try:
+                        device = SolarDevice(mac_address=dev.mac_address, manager=device_manager,
+                                             logger_name=section, config=config,
+                                             datalogger=datalogger, queue=pipeline)
+                    except Exception as e:
+                        logging.error("Could not set up device [%s]: %s", section, e)
+                        break
+                    device.on_disconnect = (lambda key=section: coordinator.mark_disconnected(key))
+                    devices[section] = device
+                    coordinator.add(section)
                     liveness.expect(section)
-                    matched += 1
-                    logging.info("Waiting for device to connect")
-                    time.sleep(1)
                     break
 
-    if matched == 0:
+    if not devices:
         logging.error("No configured devices were discovered; exiting for restart.")
         stop_event.set()
         return 1
@@ -161,11 +162,36 @@ def main(argv=None):
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
 
-    logging.debug("Waiting for devices to connect...")
-    time.sleep(10)
-
+    # The gatt main loop must run so connection callbacks (services_resolved,
+    # connect_failed, disconnect_succeeded) fire while we connect.
     loop_thread = threading.Thread(target=device_manager.run, name="gatt-mainloop", daemon=True)
     loop_thread.start()
+
+    def connect_fn(key):
+        """Connect one device and block until it resolves services, fails, or
+        times out. Serialized by the connection loop — only one at a time."""
+        device = devices[key]
+        device._connect_ok = False
+        device._connect_event.clear()
+        logging.info("[%s] Connecting to %s", key, device.mac_address)
+        try:
+            device.connect()
+        except Exception as e:
+            logging.error("[%s] connect() raised: %s", key, e)
+            return False
+        if not device._connect_event.wait(CONNECT_TIMEOUT):
+            logging.warning("[%s] connect timed out after %ss", key, CONNECT_TIMEOUT)
+            try:
+                device.disconnect()
+            except Exception:
+                pass
+            return False
+        return device._connect_ok
+
+    conn_thread = threading.Thread(
+        target=run_connection_loop, args=(coordinator, connect_fn, stop_event),
+        name="connection-loop", daemon=True)
+    conn_thread.start()
 
     logging.info("Supervising; terminate with Ctrl+C or SIGTERM")
     exit_code = supervise(device_manager, logger_future, liveness, stop_event,
@@ -173,10 +199,10 @@ def main(argv=None):
 
     stop_event.set()
     device_manager.stop()
-    for dev in device_manager.devices():
+    for device in devices.values():
         try:
-            dev.disconnect()
+            device.disconnect()
         except Exception as e:
-            logging.warning("Error disconnecting %s: %s", getattr(dev, "mac_address", "?"), e)
+            logging.warning("Error disconnecting %s: %s", getattr(device, "mac_address", "?"), e)
 
     return exit_code

--- a/monitor_app.py
+++ b/monitor_app.py
@@ -210,9 +210,13 @@ def main(argv=None):
 
     def connect_fn(key):
         """Connect one device and block until it resolves services, fails, or
-        times out. Serialized by the connection loop — only one at a time."""
+        times out. Serialized by the connection loop — only one at a time.
+
+        Deliberately does NOT scan here: scanning immediately before a connect
+        collides with it and aborts service resolution (this is what the old
+        concurrent code got right — it connected straight from the startup scan's
+        still-fresh cache). Cache freshness is kept up by _on_idle instead."""
         device = devices[key]
-        _refresh_discovery()
         device._connect_ok = False
         device._connect_event.clear()
         logging.info("[%s] Connecting to %s", key, device.mac_address)
@@ -232,17 +236,24 @@ def main(argv=None):
     rediscover = {"last": 0.0}
 
     def _on_idle():
-        """When the loop has nothing due, periodically re-scan for configured
-        devices that started advertising after startup (e.g. a battery whose BMS
-        was reset) and register them so the loop begins connecting them."""
+        """Periodically re-scan while anything is not connected. This keeps
+        BlueZ's device cache fresh for reconnects (it forgets devices it has not
+        seen, which otherwise makes a later connect fail with 'Device does not
+        exist') and registers configured devices that started advertising after
+        startup (e.g. a battery whose BMS was reset). It runs here, between
+        connects, NOT before each connect — scanning right before a connect
+        collides with it and aborts service resolution."""
         missing = [s for s in configured if s not in devices]
-        if not missing:
-            return
+        if not missing and coordinator.all_connected():
+            return   # everything registered and connected — no need to scan
         now = time.time()
         if now - rediscover["last"] < REDISCOVER_INTERVAL:
             return
         rediscover["last"] = now
-        logging.info("Re-discovering for late devices: %s", ", ".join(sorted(missing)))
+        if missing:
+            logging.info("Re-discovering (late devices / cache refresh): %s", ", ".join(sorted(missing)))
+        else:
+            logging.debug("Re-discovering to refresh the cache for disconnected devices")
         _refresh_discovery()
         for section in missing:
             _register(section)

--- a/solardevice.py
+++ b/solardevice.py
@@ -29,7 +29,9 @@ class SolarDeviceManager(gatt.DeviceManager):
 
     def device_discovered(self, device):
         logging.info("[{}] Discovered, alias = {}".format(device.mac_address, device.alias()))
-        self.stop_discovery()   # in case to stop after discovered one device
+        # NB: do NOT stop_discovery() here. It used to stop after the first device,
+        # which crippled scanning — the connection loop needs full discovery windows
+        # to keep BlueZ's device cache fresh. The loop starts/stops discovery itself.
 
     def make_device(self, mac_address):
         # if mac_address not in self._devices:
@@ -66,6 +68,10 @@ class SolarDevice(gatt.Device):
         self._connect_event = threading.Event()
         self._connect_ok = False
         self._resolved = False
+        # Set by disconnect_succeeded so a failed attempt can wait for the device
+        # to fully tear down before the next attempt (no late callbacks bleeding
+        # across attempts).
+        self._disconnect_event = threading.Event()
         self.on_disconnect = None
         self.run_device_poller = False
         self.poller_thread = None
@@ -169,6 +175,7 @@ class SolarDevice(gatt.Device):
         was_resolved = self._resolved
         self._resolved = False
         self._signal_connect_result(False)
+        self._disconnect_event.set()   # let a draining connect_fn know teardown is done
         # Only a *live* connection dropping needs re-queueing; a failed connect
         # attempt is already handled by the connection loop that awaited it.
         if was_resolved and self.on_disconnect:

--- a/solardevice.py
+++ b/solardevice.py
@@ -11,6 +11,7 @@ import sys
 import gatt
 import time
 from datetime import datetime
+import dbus
 from dbus.exceptions import DBusException
 
 # import duallog
@@ -134,6 +135,21 @@ class SolarDevice(gatt.Device):
             logging.error("[{}] DBUS-error: {}".format(self.logger_name, e))
             self._signal_connect_result(False)
             # sys.exit(100)
+
+    def set_trusted(self):
+        """Mark the device Trusted in BlueZ. A trusted device is not a
+        'temporary' device, so BlueZ keeps its object instead of removing it
+        ~30s after discovery stops (which otherwise makes a later connect fail
+        with 'Device does not exist'), and BlueZ will auto-reconnect it. gatt
+        does not expose this, so set the org.bluez.Device1 property directly.
+        The device must already be discovered (its BlueZ object must exist)."""
+        try:
+            self._properties.Set('org.bluez.Device1', 'Trusted', dbus.Boolean(True))
+            logging.info("[{}] Marked Trusted".format(self.logger_name))
+            return True
+        except Exception as e:
+            logging.warning("[{}] Could not set Trusted: {}".format(self.logger_name, e))
+            return False
 
     def _signal_connect_result(self, ok):
         """Report a connect attempt's outcome to the waiting connection loop

--- a/solardevice.py
+++ b/solardevice.py
@@ -9,7 +9,6 @@ import time
 import os
 import sys
 import gatt
-from gi.repository import GLib
 import time
 from datetime import datetime
 from dbus.exceptions import DBusException
@@ -62,6 +61,12 @@ class SolarDevice(gatt.Device):
         self.datalogger = datalogger
         self.queue = queue
         self._dropped = 0
+        # Connection coordination (see connection.py): the gatt callbacks set
+        # these; the connection loop's connect_fn awaits _connect_event.
+        self._connect_event = threading.Event()
+        self._connect_ok = False
+        self._resolved = False
+        self.on_disconnect = None
         self.run_device_poller = False
         self.poller_thread = None
         self.run_command_poller = False
@@ -121,21 +126,15 @@ class SolarDevice(gatt.Device):
             super().connect()
         except DBusException as e:
             logging.error("[{}] DBUS-error: {}".format(self.logger_name, e))
-            self._schedule_reconnect()
+            self._signal_connect_result(False)
             # sys.exit(100)
 
-    def _schedule_reconnect(self):
-        """Schedule a reconnect on the main loop. Never sleeps, never recurses —
-        connect_failed -> connect() -> connect_failed() is a recursive cycle that
-        blows the stack after ~an hour of a device being unreachable."""
-        if not self.auto_reconnect:
-            return
-        logging.info("[{}] Reconnecting in 10 seconds...".format(self.logger_name))
-        GLib.timeout_add_seconds(10, self._reconnect_cb)
-
-    def _reconnect_cb(self):
-        self.connect()
-        return False  # one-shot: do not repeat
+    def _signal_connect_result(self, ok):
+        """Report a connect attempt's outcome to the waiting connection loop
+        (connection.py). Retry/backoff is the coordinator's job, not the
+        device's — so this never schedules its own reconnect."""
+        self._connect_ok = ok
+        self._connect_event.set()
 
     def connect_succeeded(self):
         super().connect_succeeded()
@@ -152,7 +151,8 @@ class SolarDevice(gatt.Device):
             self.run_command_poller = False
             self.command_trigger.set()
             self.command_trigger.clear()
-        self._schedule_reconnect()
+        self._resolved = False
+        self._signal_connect_result(False)
 
 
     def disconnect_succeeded(self):
@@ -166,7 +166,13 @@ class SolarDevice(gatt.Device):
             self.run_command_poller = False
             self.command_trigger.set()
             self.command_trigger.clear()
-        self._schedule_reconnect()
+        was_resolved = self._resolved
+        self._resolved = False
+        self._signal_connect_result(False)
+        # Only a *live* connection dropping needs re-queueing; a failed connect
+        # attempt is already handled by the connection loop that awaited it.
+        if was_resolved and self.on_disconnect:
+            self.on_disconnect()
 
     def services_resolved(self):
         super().services_resolved()
@@ -219,6 +225,10 @@ class SolarDevice(gatt.Device):
             self.command_thread.daemon = True
             self.command_thread.name = "MQTT-poller-thread {}".format(self.logger_name)
             self.command_thread.start()
+
+        # Fully connected and usable — tell the waiting connection loop it succeeded.
+        self._resolved = True
+        self._signal_connect_result(True)
 
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,45 +1,54 @@
 import threading
 import connection
 
+NO_JITTER = lambda a, b: 0.0   # deterministic rand for exact-value assertions
+
 
 def test_backoff_grows_then_caps():
-    assert connection.backoff_seconds(1, base=5, maximum=300) == 5
-    assert connection.backoff_seconds(2, base=5, maximum=300) == 10
-    assert connection.backoff_seconds(3, base=5, maximum=300) == 20
-    assert connection.backoff_seconds(4, base=5, maximum=300) == 40
-    assert connection.backoff_seconds(100, base=5, maximum=300) == 300   # capped
+    b = lambda n: connection.backoff_seconds(n, base=5, maximum=300, rand=NO_JITTER)
+    assert b(1) == 5
+    assert b(2) == 10
+    assert b(3) == 20
+    assert b(4) == 40
+    assert b(100) == 300   # capped
 
 
 def test_backoff_clamped_not_a_bigint():
-    # A device that free-runs forever must not compute an ever-growing 2**attempt.
-    assert connection.backoff_seconds(10_000, base=5, maximum=300) == 300
+    assert connection.backoff_seconds(10_000, base=5, maximum=300, rand=NO_JITTER) == 300
 
 
 def test_backoff_attempt_floor():
-    assert connection.backoff_seconds(0, base=5, maximum=300) == 5   # treated as attempt 1
+    assert connection.backoff_seconds(0, base=5, maximum=300, rand=NO_JITTER) == 5
+
+
+def test_backoff_applies_jitter_to_spread_retries():
+    # With jitter, the delay is offset by rand(-jitter, jitter). A rand that
+    # returns its upper bound gives delay + jitter; never negative.
+    hi = connection.backoff_seconds(1, base=10, jitter=5, rand=lambda a, b: b)
+    lo = connection.backoff_seconds(1, base=10, jitter=5, rand=lambda a, b: a)
+    assert hi == 15 and lo == 5                         # first retry spread over 5..15
+    # jitter never drives the delay below zero
+    assert connection.backoff_seconds(1, base=1, jitter=100, rand=lambda a, b: a) == 0.0
 
 
 def test_maintain_backs_off_on_repeated_failure():
-    # connect_fn always fails -> backoff delays should be 5, 10, 20, ... until stop.
     delays = []
     stop = threading.Event()
 
     def connect_fn():
-        return False                      # never connects
+        return False
 
     def fake_sleep(d):
         delays.append(d)
         if len(delays) >= 4:
-            stop.set()                    # end the loop after 4 backoffs
+            stop.set()
 
     connection.maintain_device("reg", connect_fn, stop, base_backoff=5,
-                               max_backoff=300, sleep=fake_sleep)
-    assert delays == [5, 10, 20, 40]      # exponential
+                               max_backoff=300, rand=NO_JITTER, sleep=fake_sleep)
+    assert delays == [5, 10, 20, 40]
 
 
 def test_maintain_resets_backoff_after_a_good_connection():
-    # fail, fail, then a good connection (returns True) resets the backoff so the
-    # next failure starts at base again.
     outcomes = iter([False, False, True, False])
     delays = []
     stop = threading.Event()
@@ -51,13 +60,9 @@ def test_maintain_resets_backoff_after_a_good_connection():
             stop.set()
             return False
 
-    def fake_sleep(d):
-        delays.append(d)
-
     connection.maintain_device("reg", connect_fn, stop, base_backoff=5,
-                               max_backoff=300, sleep=fake_sleep)
-    # delays: 5 (after 1st fail), 10 (after 2nd fail), [True resets], 5 (after next fail)
-    assert delays == [5, 10, 5]
+                               max_backoff=300, rand=NO_JITTER, sleep=delays.append)
+    assert delays == [5, 10, 5]     # good connection resets the backoff
 
 
 def test_maintain_stops_on_event_without_calling_connect():
@@ -70,7 +75,7 @@ def test_maintain_stops_on_event_without_calling_connect():
         return False
 
     connection.maintain_device("reg", connect_fn, stop, sleep=lambda d: None)
-    assert calls["n"] == 0                 # already stopped -> never attempts
+    assert calls["n"] == 0
 
 
 def test_maintain_treats_connect_exception_as_failure():
@@ -84,5 +89,6 @@ def test_maintain_treats_connect_exception_as_failure():
         delays.append(d)
         stop.set()
 
-    connection.maintain_device("reg", connect_fn, stop, base_backoff=5, sleep=fake_sleep)
-    assert delays == [5]                   # exception -> backoff, no crash
+    connection.maintain_device("reg", connect_fn, stop, base_backoff=5,
+                               rand=NO_JITTER, sleep=fake_sleep)
+    assert delays == [5]            # exception -> backoff, no crash

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,161 +2,87 @@ import threading
 import connection
 
 
-def test_add_and_next_due_returns_disconnected_device():
-    c = connection.ConnectionCoordinator(get_time=lambda: 100.0)
-    c.add("reg")
-    assert c.next_due() == "reg"
+def test_backoff_grows_then_caps():
+    assert connection.backoff_seconds(1, base=5, maximum=300) == 5
+    assert connection.backoff_seconds(2, base=5, maximum=300) == 10
+    assert connection.backoff_seconds(3, base=5, maximum=300) == 20
+    assert connection.backoff_seconds(4, base=5, maximum=300) == 40
+    assert connection.backoff_seconds(100, base=5, maximum=300) == 300   # capped
 
 
-def test_next_due_none_when_all_connected():
-    c = connection.ConnectionCoordinator(get_time=lambda: 100.0)
-    c.add("reg")
-    c.record_result("reg", True)
-    assert c.next_due() is None
+def test_backoff_clamped_not_a_bigint():
+    # A device that free-runs forever must not compute an ever-growing 2**attempt.
+    assert connection.backoff_seconds(10_000, base=5, maximum=300) == 300
 
 
-def test_success_marks_connected_and_resets_attempts():
-    clock = {"t": 0.0}
-    c = connection.ConnectionCoordinator(get_time=lambda: clock["t"])
-    c.add("reg")
-    c.record_result("reg", False)     # one failure -> backoff
-    c.record_result("reg", True)      # then success
-    assert c.connected_count() == 1
-    assert c.next_due() is None
+def test_backoff_attempt_floor():
+    assert connection.backoff_seconds(0, base=5, maximum=300) == 5   # treated as attempt 1
 
 
-def test_backoff_grows_on_repeated_failure():
-    clock = {"t": 0.0}
-    c = connection.ConnectionCoordinator(base_backoff=5.0, max_backoff=300.0,
-                                         get_time=lambda: clock["t"])
-    c.add("reg")
-    c.record_result("reg", False)     # attempt 1 -> next at t+5
-    assert c.next_due() is None       # not due yet
-    clock["t"] = 5.0
-    assert c.next_due() == "reg"      # now due
-    c.record_result("reg", False)     # attempt 2 -> next at t+10
-    clock["t"] = 9.0
-    assert c.next_due() is None
-    clock["t"] = 15.0
-    assert c.next_due() == "reg"
-
-
-def test_backoff_capped_at_max():
-    clock = {"t": 0.0}
-    c = connection.ConnectionCoordinator(base_backoff=5.0, max_backoff=20.0,
-                                         get_time=lambda: clock["t"])
-    c.add("reg")
-    for _ in range(10):
-        c.record_result("reg", False)
-    # next_attempt must never be more than max_backoff away
-    clock["t"] = 20.0
-    assert c.next_due() == "reg"
-
-
-def test_mark_disconnected_requeues_a_connected_device():
-    clock = {"t": 0.0}
-    c = connection.ConnectionCoordinator(base_backoff=5.0, get_time=lambda: clock["t"])
-    c.add("reg")
-    c.record_result("reg", True)
-    assert c.next_due() is None
-    c.mark_disconnected("reg")        # dropped -> requeue with backoff
-    assert c.next_due() is None       # brief backoff first
-    clock["t"] = 5.0
-    assert c.next_due() == "reg"
-
-
-def test_run_loop_is_serial_and_applies_backoff():
-    # connect_fn records call order and returns per a script; the loop must call
-    # it ONE AT A TIME and stop when everything is connected.
-    clock = {"t": 0.0}
-    c = connection.ConnectionCoordinator(base_backoff=5.0, get_time=lambda: clock["t"])
-    for k in ("reg", "batt", "inv"):
-        c.add(k)
-
-    calls = []
-    inflight = {"n": 0, "max": 0}
-    lock = threading.Lock()
-    results = {"reg": [True], "batt": [False, True], "inv": [True]}
-
-    def connect_fn(key):
-        with lock:
-            inflight["n"] += 1
-            inflight["max"] = max(inflight["max"], inflight["n"])
-        calls.append(key)
-        clock["t"] += 5.0            # advance clock so backoff elapses between rounds
-        outcome = results[key].pop(0)
-        with lock:
-            inflight["n"] -= 1
-        return outcome
-
+def test_maintain_backs_off_on_repeated_failure():
+    # connect_fn always fails -> backoff delays should be 5, 10, 20, ... until stop.
+    delays = []
     stop = threading.Event()
 
-    def on_idle():
-        # stop once every device is connected
-        if c.all_connected():
+    def connect_fn():
+        return False                      # never connects
+
+    def fake_sleep(d):
+        delays.append(d)
+        if len(delays) >= 4:
+            stop.set()                    # end the loop after 4 backoffs
+
+    connection.maintain_device("reg", connect_fn, stop, base_backoff=5,
+                               max_backoff=300, sleep=fake_sleep)
+    assert delays == [5, 10, 20, 40]      # exponential
+
+
+def test_maintain_resets_backoff_after_a_good_connection():
+    # fail, fail, then a good connection (returns True) resets the backoff so the
+    # next failure starts at base again.
+    outcomes = iter([False, False, True, False])
+    delays = []
+    stop = threading.Event()
+
+    def connect_fn():
+        try:
+            return next(outcomes)
+        except StopIteration:
             stop.set()
+            return False
 
-    connection.run_connection_loop(
-        c, connect_fn, stop, get_time=lambda: clock["t"],
-        sleep=lambda s: None, on_idle=on_idle,
-    )
+    def fake_sleep(d):
+        delays.append(d)
 
-    assert inflight["max"] == 1               # never more than one connect in flight
-    assert c.all_connected()                  # every device ended connected
-    assert calls.count("batt") == 2           # batt retried after its one failure
+    connection.maintain_device("reg", connect_fn, stop, base_backoff=5,
+                               max_backoff=300, sleep=fake_sleep)
+    # delays: 5 (after 1st fail), 10 (after 2nd fail), [True resets], 5 (after next fail)
+    assert delays == [5, 10, 5]
 
 
-def test_run_loop_stops_on_event():
-    c = connection.ConnectionCoordinator()
+def test_maintain_stops_on_event_without_calling_connect():
     stop = threading.Event()
     stop.set()
-    # already stopped -> returns immediately without calling connect_fn
-    connection.run_connection_loop(c, lambda k: True, stop, sleep=lambda s: None)
+    calls = {"n": 0}
+
+    def connect_fn():
+        calls["n"] += 1
+        return False
+
+    connection.maintain_device("reg", connect_fn, stop, sleep=lambda d: None)
+    assert calls["n"] == 0                 # already stopped -> never attempts
 
 
-def test_backoff_exponent_is_clamped_not_a_bigint():
-    # A device that free-runs for a very long time must not compute an ever-
-    # growing 2**attempts; the exponent is clamped and the result stays <= max.
-    c = connection.ConnectionCoordinator(base_backoff=5.0, max_backoff=300.0,
-                                         get_time=lambda: 0.0)
-    assert c._backoff(1000) == 300.0        # clamped, no MemoryError / huge int
-
-
-def test_coordinator_is_thread_safe_under_concurrent_access():
-    # The real system calls mark_disconnected() from the gatt callback thread
-    # while next_due()/record_result() run on the connection-loop thread. With
-    # the lock this must not deadlock or raise; without it, _state access races.
-    import time as _time
-    c = connection.ConnectionCoordinator(base_backoff=0.0)
-    for k in ("a", "b", "c", "d"):
-        c.add(k)
+def test_maintain_treats_connect_exception_as_failure():
+    delays = []
     stop = threading.Event()
-    errors = []
 
-    def loop_worker():
-        try:
-            while not stop.is_set():
-                k = c.next_due()
-                if k is not None:
-                    c.record_result(k, True)
-        except Exception as e:  # pragma: no cover - failure path
-            errors.append(e)
+    def connect_fn():
+        raise RuntimeError("boom")
 
-    def drop_worker():
-        try:
-            while not stop.is_set():
-                for k in ("a", "b", "c", "d"):
-                    c.mark_disconnected(k)
-        except Exception as e:  # pragma: no cover - failure path
-            errors.append(e)
+    def fake_sleep(d):
+        delays.append(d)
+        stop.set()
 
-    threads = [threading.Thread(target=loop_worker) for _ in range(3)]
-    threads += [threading.Thread(target=drop_worker) for _ in range(3)]
-    for t in threads:
-        t.start()
-    _time.sleep(0.3)
-    stop.set()
-    for t in threads:
-        t.join(timeout=2)
-    assert errors == []
-    assert not any(t.is_alive() for t in threads)
+    connection.maintain_device("reg", connect_fn, stop, base_backoff=5, sleep=fake_sleep)
+    assert delays == [5]                   # exception -> backoff, no crash

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -112,3 +112,51 @@ def test_run_loop_stops_on_event():
     stop.set()
     # already stopped -> returns immediately without calling connect_fn
     connection.run_connection_loop(c, lambda k: True, stop, sleep=lambda s: None)
+
+
+def test_backoff_exponent_is_clamped_not_a_bigint():
+    # A device that free-runs for a very long time must not compute an ever-
+    # growing 2**attempts; the exponent is clamped and the result stays <= max.
+    c = connection.ConnectionCoordinator(base_backoff=5.0, max_backoff=300.0,
+                                         get_time=lambda: 0.0)
+    assert c._backoff(1000) == 300.0        # clamped, no MemoryError / huge int
+
+
+def test_coordinator_is_thread_safe_under_concurrent_access():
+    # The real system calls mark_disconnected() from the gatt callback thread
+    # while next_due()/record_result() run on the connection-loop thread. With
+    # the lock this must not deadlock or raise; without it, _state access races.
+    import time as _time
+    c = connection.ConnectionCoordinator(base_backoff=0.0)
+    for k in ("a", "b", "c", "d"):
+        c.add(k)
+    stop = threading.Event()
+    errors = []
+
+    def loop_worker():
+        try:
+            while not stop.is_set():
+                k = c.next_due()
+                if k is not None:
+                    c.record_result(k, True)
+        except Exception as e:  # pragma: no cover - failure path
+            errors.append(e)
+
+    def drop_worker():
+        try:
+            while not stop.is_set():
+                for k in ("a", "b", "c", "d"):
+                    c.mark_disconnected(k)
+        except Exception as e:  # pragma: no cover - failure path
+            errors.append(e)
+
+    threads = [threading.Thread(target=loop_worker) for _ in range(3)]
+    threads += [threading.Thread(target=drop_worker) for _ in range(3)]
+    for t in threads:
+        t.start()
+    _time.sleep(0.3)
+    stop.set()
+    for t in threads:
+        t.join(timeout=2)
+    assert errors == []
+    assert not any(t.is_alive() for t in threads)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,114 @@
+import threading
+import connection
+
+
+def test_add_and_next_due_returns_disconnected_device():
+    c = connection.ConnectionCoordinator(get_time=lambda: 100.0)
+    c.add("reg")
+    assert c.next_due() == "reg"
+
+
+def test_next_due_none_when_all_connected():
+    c = connection.ConnectionCoordinator(get_time=lambda: 100.0)
+    c.add("reg")
+    c.record_result("reg", True)
+    assert c.next_due() is None
+
+
+def test_success_marks_connected_and_resets_attempts():
+    clock = {"t": 0.0}
+    c = connection.ConnectionCoordinator(get_time=lambda: clock["t"])
+    c.add("reg")
+    c.record_result("reg", False)     # one failure -> backoff
+    c.record_result("reg", True)      # then success
+    assert c.connected_count() == 1
+    assert c.next_due() is None
+
+
+def test_backoff_grows_on_repeated_failure():
+    clock = {"t": 0.0}
+    c = connection.ConnectionCoordinator(base_backoff=5.0, max_backoff=300.0,
+                                         get_time=lambda: clock["t"])
+    c.add("reg")
+    c.record_result("reg", False)     # attempt 1 -> next at t+5
+    assert c.next_due() is None       # not due yet
+    clock["t"] = 5.0
+    assert c.next_due() == "reg"      # now due
+    c.record_result("reg", False)     # attempt 2 -> next at t+10
+    clock["t"] = 9.0
+    assert c.next_due() is None
+    clock["t"] = 15.0
+    assert c.next_due() == "reg"
+
+
+def test_backoff_capped_at_max():
+    clock = {"t": 0.0}
+    c = connection.ConnectionCoordinator(base_backoff=5.0, max_backoff=20.0,
+                                         get_time=lambda: clock["t"])
+    c.add("reg")
+    for _ in range(10):
+        c.record_result("reg", False)
+    # next_attempt must never be more than max_backoff away
+    clock["t"] = 20.0
+    assert c.next_due() == "reg"
+
+
+def test_mark_disconnected_requeues_a_connected_device():
+    clock = {"t": 0.0}
+    c = connection.ConnectionCoordinator(base_backoff=5.0, get_time=lambda: clock["t"])
+    c.add("reg")
+    c.record_result("reg", True)
+    assert c.next_due() is None
+    c.mark_disconnected("reg")        # dropped -> requeue with backoff
+    assert c.next_due() is None       # brief backoff first
+    clock["t"] = 5.0
+    assert c.next_due() == "reg"
+
+
+def test_run_loop_is_serial_and_applies_backoff():
+    # connect_fn records call order and returns per a script; the loop must call
+    # it ONE AT A TIME and stop when everything is connected.
+    clock = {"t": 0.0}
+    c = connection.ConnectionCoordinator(base_backoff=5.0, get_time=lambda: clock["t"])
+    for k in ("reg", "batt", "inv"):
+        c.add(k)
+
+    calls = []
+    inflight = {"n": 0, "max": 0}
+    lock = threading.Lock()
+    results = {"reg": [True], "batt": [False, True], "inv": [True]}
+
+    def connect_fn(key):
+        with lock:
+            inflight["n"] += 1
+            inflight["max"] = max(inflight["max"], inflight["n"])
+        calls.append(key)
+        clock["t"] += 5.0            # advance clock so backoff elapses between rounds
+        outcome = results[key].pop(0)
+        with lock:
+            inflight["n"] -= 1
+        return outcome
+
+    stop = threading.Event()
+
+    def on_idle():
+        # stop once every device is connected
+        if c.all_connected():
+            stop.set()
+
+    connection.run_connection_loop(
+        c, connect_fn, stop, get_time=lambda: clock["t"],
+        sleep=lambda s: None, on_idle=on_idle,
+    )
+
+    assert inflight["max"] == 1               # never more than one connect in flight
+    assert c.all_connected()                  # every device ended connected
+    assert calls.count("batt") == 2           # batt retried after its one failure
+
+
+def test_run_loop_stops_on_event():
+    c = connection.ConnectionCoordinator()
+    stop = threading.Event()
+    stop.set()
+    # already stopped -> returns immediately without calling connect_fn
+    connection.run_connection_loop(c, lambda k: True, stop, sleep=lambda s: None)

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -43,6 +43,15 @@ def test_disconnect_of_a_live_connection_requeues_via_on_disconnect():
     assert dev._resolved is False
 
 
+def test_disconnect_sets_the_drain_event():
+    # A failed connect_fn drains by waiting on _disconnect_event; disconnect_
+    # succeeded must set it so teardown can't bleed into the next attempt.
+    dev = _bare_device()
+    assert not dev._disconnect_event.is_set()
+    dev.disconnect_succeeded()
+    assert dev._disconnect_event.is_set()
+
+
 def test_disconnect_during_a_failed_attempt_does_not_requeue():
     dev = _bare_device()
     dev._resolved = False                    # was never resolved (attempt failed)

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -43,6 +43,13 @@ def test_disconnect_of_a_live_connection_requeues_via_on_disconnect():
     assert dev._resolved is False
 
 
+def test_set_trusted_is_defensive_when_dbus_object_missing():
+    # On a bare (unmanaged) device the gatt dbus properties object isn't set up;
+    # set_trusted must not raise, just return False and log.
+    dev = _bare_device()
+    assert dev.set_trusted() is False
+
+
 def test_disconnect_sets_the_drain_event():
     # A failed connect_fn drains by waiting on _disconnect_event; disconnect_
     # succeeded must set it so teardown can't bleed into the next attempt.

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -1,43 +1,63 @@
+import inspect
 import solardevice
 
 
-def _reconnecting_device():
+def _bare_device():
+    # type=None -> __init__ returns early (no plugin/gatt setup), giving a
+    # lightweight object with the connection-signalling attributes present.
     dev = solardevice.SolarDevice(mac_address="aa:bb:cc:dd:ee:ff", manager=None)
-    dev.auto_reconnect = True
     dev.logger_name = "reg"
     dev.poller_thread = None
     dev.command_thread = None
     return dev
 
 
-def test_schedule_reconnect_uses_glib_and_does_not_recurse(fake_glib):
-    dev = _reconnecting_device()
-    connect_calls = {"n": 0}
-    dev.connect = lambda: connect_calls.__setitem__("n", connect_calls["n"] + 1)
-
-    dev._schedule_reconnect()
-
-    # It scheduled a delayed retry rather than calling connect() synchronously.
-    assert connect_calls["n"] == 0
-    assert len(fake_glib.scheduled) == 1
-    delay, cb = fake_glib.scheduled[0]
-    assert delay == 10
-    # The scheduled callback returns False (one-shot) and calls connect once.
-    assert cb() is False
-    assert connect_calls["n"] == 1
+def test_signal_connect_result_sets_event_and_flag():
+    dev = _bare_device()
+    assert not dev._connect_event.is_set()
+    dev._signal_connect_result(True)
+    assert dev._connect_event.is_set()
+    assert dev._connect_ok is True
+    dev._connect_event.clear()
+    dev._signal_connect_result(False)
+    assert dev._connect_event.is_set()
+    assert dev._connect_ok is False
 
 
-def test_schedule_reconnect_noop_when_disabled(fake_glib):
-    dev = _reconnecting_device()
-    dev.auto_reconnect = False
-    dev._schedule_reconnect()
-    assert fake_glib.scheduled == []
+def test_connect_failed_signals_failure_to_the_waiting_loop():
+    dev = _bare_device()
+    dev.connect_failed("le-connection-abort-by-local")
+    assert dev._connect_event.is_set()
+    assert dev._connect_ok is False
+    assert dev._resolved is False
 
 
-import inspect
+def test_disconnect_of_a_live_connection_requeues_via_on_disconnect():
+    dev = _bare_device()
+    dev._resolved = True                     # simulate a fully-connected device
+    called = {"n": 0}
+    dev.on_disconnect = lambda: called.__setitem__("n", called["n"] + 1)
+    dev.disconnect_succeeded()
+    assert called["n"] == 1                  # live drop -> re-queued
+    assert dev._connect_event.is_set()       # also unblocks any waiter
+    assert dev._resolved is False
 
 
-def test_no_time_sleep_in_gatt_callbacks():
+def test_disconnect_during_a_failed_attempt_does_not_requeue():
+    dev = _bare_device()
+    dev._resolved = False                    # was never resolved (attempt failed)
+    called = {"n": 0}
+    dev.on_disconnect = lambda: called.__setitem__("n", called["n"] + 1)
+    dev.disconnect_succeeded()
+    assert called["n"] == 0                  # the connection loop handles this one
+    assert dev._connect_event.is_set()
+
+
+def test_no_time_sleep_or_glib_reconnect_in_gatt_callbacks():
+    # gatt callbacks must not block, and must not schedule their own reconnect
+    # (retry/backoff is the coordinator's job now).
     src = inspect.getsource(solardevice.SolarDevice.connect_failed)
     src += inspect.getsource(solardevice.SolarDevice.disconnect_succeeded)
+    src += inspect.getsource(solardevice.SolarDevice.connect)
     assert "time.sleep" not in src, "gatt callback must not block on time.sleep"
+    assert "GLib" not in src, "device must not schedule its own reconnect"


### PR DESCRIPTION
Extracts the BLE connection-reliability work onto `master`. These eight commits currently exist only on `feat/connection-reliability`, which is what runs in production at Leveld — they are in no PR, so master has no copy.

Refs #52.

## What it does
- **Serial connection coordinator** with exponential backoff, `gatt`-free and unit-testable (the connect itself is injected as `connect_fn`).
- **Concurrent per-device connect** after discovery — strict serialization made the transient GATT-resolution aborts worse, not better.
- **Backoff jitter**, so retries across devices don't all land at once.
- **BlueZ trust** (`set_trusted`), which stops BlueZ discarding a device as "temporary" after ~30 s and lets it auto-reconnect.
- **Auto-discovery** of configured devices that appear after startup, and no scan immediately before a connect.

`connection.py`, `monitor_app.py`, `solardevice.py`, plus tests. 47 passing.

## Relationship to #54 — needs a decision
#54 (bleak transport) does **not** contain these commits, but it does carry the surviving half of this work in reworked form: its `connection.py` is a 28-line reduction of the 69 lines here, keeping `backoff_seconds` and dropping the thread-based `maintain_device` in favour of the asyncio one in `ble.py`. `set_trusted` and the jitter policy are on that branch too, and it rewrites `monitor_app.py` and `solardevice.py` heavily.

So this PR and #54 overlap and will conflict. Two ways out:

1. Merge this first, then rebase #54 on top — this becomes the provenance of the policy #54 reduces.
2. Close this and let #54 be the delivery vehicle, accepting that the thread-based coordinator never lands on master in its own right.

Opened as a draft because that choice is yours; the point is that master currently has no copy of this at all.
