### PR TITLE
Request SolarPanelAndBatteryState in the SolarLink poll loop

### DIFF
--- a/plugins/SolarLink/__init__.py
+++ b/plugins/SolarLink/__init__.py
@@ -97,8 +97,8 @@ class Util():
             data = self.create_poll_request('BatteryParamInfo')
         if self.poll_loop_count == 3:
             data = self.create_poll_request('SolarPanelInfo')
-        # if self.poll_loop_count == 5:
-        #     self.create_poll_request('SolarPanelAndBatteryState')
+        if self.poll_loop_count == 5:
+            data = self.create_poll_request('SolarPanelAndBatteryState')
         # if self.poll_loop_count == 7:
         #     self.create_poll_request('ParamSettingData')
         if self.poll_loop_count == 10:


### PR DESCRIPTION
Enables the `SolarPanelAndBatteryState` poll in `SolarLink.pollRequest`, at loop count 5.

## Why
The response path for this frame already exists in full — the request class (`REG_ADDR 288`, `READ_WORD 3`, `RESP_ID 6`), the dispatch in `notificationUpdate`, and `updateSolarPanelAndBatteryState`. Nothing ever requested it, so none of that code has been reachable.

The commented-out line also had a bug: it called `self.create_poll_request(...)` without assigning to `data`. Every other branch in `pollRequest` assigns, and `data` is what gets returned and written — so uncommenting it verbatim would have built a request and thrown it away.

## What this does and does not give you
`updateSolarPanelAndBatteryState` currently only logs at debug — panel state, battery state and controller info — and sets **no entities**. So this PR makes the frame arrive and become inspectable; it does not add anything to Home Assistant on its own. It's the prerequisite for decoding those three fields, at the cost of one extra request per ten-poll cycle.

Lifted from the working tree running in production at Leveld. 47 tests passing.
