### PR TITLE
One signed-int decoder; wrap points as named constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,10 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install test dependencies
-        # gatt/dbus/paho/gi are stubbed in tests/conftest.py; requests is a real
-        # runtime dep imported by datalogger and exercised by a test.
-        run: pip install pytest requests
+        # gatt/dbus/paho/gi/libscrc are stubbed in tests/conftest.py (system or
+        # C-extension packages). requests and python-dateutil are pure-Python
+        # runtime deps imported at module level by code under test.
+        run: pip install pytest requests python-dateutil
       - name: Byte-compile (syntax gate)
         run: python -m py_compile monitor_app.py solar-monitor.py supervisor.py solardevice.py datalogger.py duallog.py ble.py connection.py
       - name: Run tests

--- a/codec.py
+++ b/codec.py
@@ -1,0 +1,27 @@
+"""Shared wire-format decoding helpers.
+
+Separate from `solardevice` so plugins can import it without a cycle:
+`solardevice` imports plugins, never the reverse.
+"""
+
+# Two's-complement wrap points. A reading above the signed maximum is negative
+# and wraps by 2**bits. Every plugin open-coded this with its own constant and
+# each was short of 2**bits: Meritsun and Topband by one LSB (2**32 - 1),
+# RenogyBatt by two (65534, not 65536, for both current and temperature). So
+# every negative reading came out high -- by +0.02 A on RenogyBatt current,
+# which integrates into roughly 1.7 Ah/day of phantom charge.
+UINT16_WRAP = 1 << 16      # 65536
+UINT32_WRAP = 1 << 32      # 4294967296
+INT16_MAX = (1 << 15) - 1  # 32767
+INT32_MAX = (1 << 31) - 1  # 2147483647
+
+
+def to_signed(value, wrap, threshold):
+    """Interpret a two's-complement reading as signed.
+
+    `wrap` and `threshold` are in the same units as `value`, so a caller that
+    has already scaled the raw word passes scaled bounds (see RenogyBatt).
+    `threshold` is separate from `wrap // 2 - 1` because some devices use a
+    practical bound rather than the arithmetic sign bit.
+    """
+    return value - wrap if value > threshold else value

--- a/plugins/Meritsun/__init__.py
+++ b/plugins/Meritsun/__init__.py
@@ -9,6 +9,8 @@ from datetime import datetime
 # import duallog
 import logging
 
+from codec import INT32_MAX, UINT32_WRAP, to_signed
+
 # duallog.setup('SmartPower', minLevel=logging.INFO)
 
 
@@ -227,9 +229,7 @@ class Util():
         # decoded on every framed packet; each entity setter validates its own
         # value against physical bounds and rejects any that slipped through.
         self.PowerDevice.entities.mvoltage = mvoltage
-        mcurrent = self.getValue(message, 8, 15)
-        if mcurrent > 2147483647:
-            mcurrent = mcurrent - 4294967295
+        mcurrent = to_signed(self.getValue(message, 8, 15), UINT32_WRAP, INT32_MAX)
         self.PowerDevice.entities.mcurrent = mcurrent
         self.PowerDevice.entities.mcapacity = self.getValue(message, 16, 23)
         self.PowerDevice.entities.charge_cycles = self.getValue(message, 24, 27)

--- a/plugins/RenogyBatt/__init__.py
+++ b/plugins/RenogyBatt/__init__.py
@@ -1,8 +1,20 @@
 import logging
+
+from codec import UINT16_WRAP, to_signed
 import libscrc
 import dateutil.parser
 import re
 from datetime import datetime
+
+# The pack reports current and temperature as 16-bit two's complement, scaled at
+# the point of use. The sign threshold is a practical bound, not the arithmetic
+# one (32767 raw): no pack reaches 255 A or 255 C, and the device uses the top of
+# the range for negatives.
+CURRENT_SCALE = .01
+TEMPERATURE_SCALE = .1
+CURRENT_WRAP = UINT16_WRAP * CURRENT_SCALE          # 655.36
+TEMPERATURE_WRAP = UINT16_WRAP * TEMPERATURE_SCALE  # 6553.6
+SIGN_THRESHOLD = 255
 
 class Config():
     NOTIFY_SERVICE_UUID = "0000fff0-0000-1000-8000-00805f9b34fb"
@@ -188,9 +200,8 @@ class Util():
         self.PowerDevice.entities.soc = capacity/self.max_capacity * 100
         self.PowerDevice.entities.max_capacity = self.max_capacity
 
-        current = self.Bytes2Int(bs, 3, 2) * .01
-        if current > 255:
-            current = current - 655.34
+        current = to_signed(self.Bytes2Int(bs, 3, 2) * CURRENT_SCALE,
+                            CURRENT_WRAP, SIGN_THRESHOLD)
         self.PowerDevice.entities.current = current
         self.updateCapacityFromCurrent()
         self.PowerDevice.entities.voltage = self.Bytes2Int(bs, 5, 2) * .1
@@ -216,9 +227,8 @@ class Util():
             local_s = 5 + (j*2)
             logging.debug("Temperature {} {} => {}".format(
                 int(bs[local_s]),int(bs[local_s+1]), self.Bytes2Int(bs, local_s, 2) * .1))
-            temperature = self.Bytes2Int(bs, local_s, 2) * .1
-            if temperature > 255:
-                temperature = temperature - 6553.4
+            temperature = to_signed(self.Bytes2Int(bs, local_s, 2) * TEMPERATURE_SCALE,
+                                    TEMPERATURE_WRAP, SIGN_THRESHOLD)
             self.PowerDevice.entities.temperature_celsius = temperature
             self.PowerDevice.entities.battery_temperature_celsius = temperature
         return

--- a/plugins/Topband/__init__.py
+++ b/plugins/Topband/__init__.py
@@ -9,6 +9,8 @@ from datetime import datetime
 # import duallog
 import logging
 
+from codec import INT32_MAX, UINT32_WRAP, to_signed
+
 # duallog.setup('SmartPower', minLevel=logging.INFO)
 
 
@@ -153,9 +155,7 @@ class Util():
         # if self.DeviceType == '12V100Ah-027':
         self.PowerDevice.entities.mvoltage = self.getValue(message, 0, 7)
         logging.debug("mVoltage: {}".format(self.getValue(message, 0, 7)))
-        mcurrent = self.getValue(message, 8, 15)
-        if mcurrent > 2147483647:
-            mcurrent = mcurrent - 4294967295
+        mcurrent = to_signed(self.getValue(message, 8, 15), UINT32_WRAP, INT32_MAX)
         self.PowerDevice.entities.mcurrent = mcurrent
         self.PowerDevice.entities.mcapacity = self.getValue(message, 16, 23)
         self.PowerDevice.entities.charge_cycles = self.getValue(message, 24, 27)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,10 +123,28 @@ def _install_gi_stub():
     sys.modules["gi.repository"] = repository
 
 
+def _install_libscrc_stub():
+    """`libscrc` is a C extension used by RenogyBatt for Modbus CRCs. Tests that
+    import that plugin only need the module to resolve at import time; nothing
+    exercises a CRC, so a stub that raises if actually called is honest."""
+    if "libscrc" in sys.modules:
+        return
+
+    libscrc = types.ModuleType("libscrc")
+
+    def _unavailable(*args, **kwargs):
+        raise NotImplementedError("libscrc is stubbed in tests; no test exercises a CRC")
+
+    libscrc.modbus = _unavailable
+
+    sys.modules["libscrc"] = libscrc
+
+
 _install_dbus_stub()
 _install_gatt_stub()
 _install_paho_stub()
 _install_gi_stub()
+_install_libscrc_stub()
 
 
 import pytest

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,0 +1,59 @@
+"""Two's-complement decoding shared by the battery plugins.
+
+Each plugin used to open-code this with its own constant, and all four were one
+LSB short (2**bits - 1 instead of 2**bits).
+"""
+
+import pytest
+
+from codec import INT32_MAX, UINT16_WRAP, UINT32_WRAP, to_signed
+from plugins.RenogyBatt import CURRENT_WRAP, SIGN_THRESHOLD, TEMPERATURE_WRAP
+
+
+def test_positive_values_pass_through():
+    assert to_signed(1000, UINT32_WRAP, INT32_MAX) == 1000
+    assert to_signed(INT32_MAX, UINT32_WRAP, INT32_MAX) == INT32_MAX
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (UINT32_WRAP - 1, -1),
+        (UINT32_WRAP - 1000, -1000),
+        (INT32_MAX + 1, -(INT32_MAX + 1)),
+    ],
+)
+def test_negative_32bit_values(raw, expected):
+    assert to_signed(raw, UINT32_WRAP, INT32_MAX) == expected
+
+
+def test_one_lsb_negative_is_not_zero():
+    """The old constant (2**32 - 1) decoded -1 as 0."""
+    assert to_signed(UINT32_WRAP - 1, UINT32_WRAP, INT32_MAX) == -1
+    assert (UINT32_WRAP - 1) - (UINT32_WRAP - 1) == 0  # what it used to do
+
+
+def test_renogy_wrap_points():
+    assert CURRENT_WRAP == 655.36
+    assert TEMPERATURE_WRAP == 6553.6
+
+
+def test_renogy_current_smallest_discharge():
+    """Raw 65535 is one LSB negative: -0.01 A, not the +0.01 A it used to give."""
+    assert to_signed(65535 * .01, CURRENT_WRAP, SIGN_THRESHOLD) == pytest.approx(-0.01)
+    assert 65535 * .01 - 655.34 == pytest.approx(+0.01)  # the old bias, 0.02 A high
+
+
+def test_renogy_current_charging_unaffected():
+    assert to_signed(12.34, CURRENT_WRAP, SIGN_THRESHOLD) == pytest.approx(12.34)
+
+
+def test_renogy_temperature_below_zero():
+    assert to_signed(65531 * .1, TEMPERATURE_WRAP, SIGN_THRESHOLD) == pytest.approx(-0.5)
+
+
+def test_threshold_is_practical_not_arithmetic():
+    """Renogy signs off 255, not the 16-bit sign bit -- a 300 A reading is negative."""
+    assert SIGN_THRESHOLD == 255
+    assert to_signed(300.0, CURRENT_WRAP, SIGN_THRESHOLD) < 0
+    assert UINT16_WRAP // 2 - 1 != SIGN_THRESHOLD


### PR DESCRIPTION
First Tier-1 item from #46: one signed-int decoder in place of four hand-written constants.

## The bug
All four plugins open-coded two's-complement conversion, and every constant was short of `2**bits` — but not by the same amount:

| plugin | field | was | raw LSBs | short by | now |
|---|---|---|---|---|---|
| RenogyBatt | current | `655.34` | 65534 | **2 LSB** | `UINT16_WRAP * .01` = 655.36 |
| RenogyBatt | temperature | `6553.4` | 65534 | **2 LSB** | `UINT16_WRAP * .1` = 6553.6 |
| Meritsun | current | `4294967295` | — | 1 LSB | `UINT32_WRAP` = 4294967296 |
| Topband | current | `4294967295` | — | 1 LSB | `UINT32_WRAP` = 4294967296 |

So every negative reading came out high. On RenogyBatt current that is **+0.02 A** on each discharge sample — two LSBs at 0.01 A, which is where the ~1.7 Ah/day of phantom charge in #46 comes from. Temperature is +0.2 °C the same way.

Concretely: raw 65535 is one LSB negative. It decoded as **+0.01 A** and should be **−0.01 A**.

## The change
New `codec.py` holds the wrap points and signed maxima as named constants plus a single `to_signed(value, wrap, threshold)`. It lives outside `solardevice` so plugins can import it without a cycle — `solardevice` imports plugins, never the reverse.

`wrap` and `threshold` are in the caller's units, so a plugin that has already scaled the raw word passes scaled bounds. That's what RenogyBatt needs.

## One thing deliberately not changed
RenogyBatt signs off a threshold of **255**, not the arithmetic sign bit (32767 raw). No pack reaches 255 A or 255 °C, so it works, but it is a practical bound rather than the wire format. Changing it needs a real device, so it stays as-is — now named `SIGN_THRESHOLD` instead of inline, with a comment saying why. A test pins the current behaviour.

## Tests
`tests/test_codec.py`, 10 cases: sign conversion at the boundaries, the Renogy wrap points, the one-LSB case with the old bias asserted alongside the new value, and that the threshold is practical rather than arithmetic. Full suite 57 passing.
