### PR TITLE
Don't raise when a plugin implements no commands

### DIFF
--- a/solardevice.py
+++ b/solardevice.py
@@ -116,7 +116,16 @@ class SolarDevice:
         return self.util.pollRequest() if self.util else None
 
     def run_command(self, var, message):
-        for data in self.util.cmdRequest(var, message):
+        # Only two of the six plugins implement cmdRequest; the rest are
+        # read-only devices. Treat "no commands" as empty rather than letting an
+        # AttributeError reach the caller, where it surfaces as a logged
+        # traceback and a command that silently does nothing.
+        cmd_request = getattr(self.util, "cmdRequest", None)
+        if cmd_request is None:
+            logging.warning("[{}] plugin '{}' accepts no commands; ignoring {} = {}".format(
+                self.logger_name, self.type, var, message))
+            return
+        for data in cmd_request(var, message):
             self.characteristic_write_value(data, self.device_write_characteristic_commands)
 
     def _enqueue(self, item):

--- a/tests/test_run_command.py
+++ b/tests/test_run_command.py
@@ -1,0 +1,57 @@
+"""`run_command` against plugins that do and don't implement cmdRequest.
+
+Four of the six plugins (Hacien, Meritsun, RenogyBatt, Topband) are read-only
+and define no `cmdRequest`. An MQTT `set` addressed to one of those used to
+raise AttributeError out of `run_command`.
+"""
+
+import pytest
+
+from solardevice import SolarDevice
+
+
+class _Util:
+    """A plugin that implements commands."""
+
+    def __init__(self):
+        self.calls = []
+
+    def cmdRequest(self, command, value):
+        self.calls.append((command, value))
+        return [b"\x01\x02", b"\x03"]
+
+
+class _ReadOnlyUtil:
+    """A plugin that does not -- four of the six shipped ones."""
+
+
+@pytest.fixture
+def device():
+    dev = SolarDevice.__new__(SolarDevice)      # bypass BLE setup
+    dev.logger_name = "test-device"
+    dev.type = "Meritsun"
+    dev.device_write_characteristic_commands = "char-uuid"
+    dev.writes = []
+    dev.characteristic_write_value = lambda data, char: dev.writes.append((data, char))
+    return dev
+
+
+def test_command_reaches_the_device(device):
+    device.util = _Util()
+    device.run_command("power_switch", "on")
+    assert device.util.calls == [("power_switch", "on")]
+    assert device.writes == [(b"\x01\x02", "char-uuid"), (b"\x03", "char-uuid")]
+
+
+def test_read_only_plugin_does_not_raise(device):
+    device.util = _ReadOnlyUtil()
+    device.run_command("power_switch", "on")     # must not raise
+    assert device.writes == []
+
+
+def test_read_only_plugin_is_logged(device, caplog):
+    device.util = _ReadOnlyUtil()
+    with caplog.at_level("WARNING"):
+        device.run_command("power_switch", "on")
+    assert "accepts no commands" in caplog.text
+    assert "test-device" in caplog.text


### PR DESCRIPTION
Next Tier-1 item from #46: `cmdRequest` missing on four of the six plugins.

## The bug
`SolarDevice.run_command` called `self.util.cmdRequest(...)` unguarded, but only **SolarLink** and **VEDirect** define it. `Hacien`, `Meritsun`, `RenogyBatt` and `Topband` are read-only, so an MQTT `set` addressed to any of them raised `AttributeError`.

## Correction to the issue text
#46 says this "kills the poller on any MQTT `set`". That was true when the issue was written; **#54 changed it**. `BleManager.submit_command` now wraps the call:

```python
async def _cmd():
    try:
        dev.run_command(var, value)
    except Exception as e:
        logging.error("[%s] command %s failed: %r", dev.logger_name, var, e)
```

So today the symptom is a logged traceback and a command that silently does nothing — worth fixing, but not fatal. I'll update the issue.

## The fix
Treat a missing `cmdRequest` as "this plugin accepts no commands" and log it at WARNING with the device and plugin named, instead of raising. One guard covers all four plugins and any future read-only one.

When #46's shared plugin bases land, this belongs there as a default returning `[]` — the guard is the same behaviour without waiting for them.

## Tests
`tests/test_run_command.py`, 3 cases: a command reaches the device and writes each payload to the commands characteristic; a read-only plugin doesn't raise; and it says so in the log. The two read-only cases fail on `master` and pass here. Full suite 60 passing.
