### PR TITLE
One bounds-checked frame accessor for the ASCII-hex plugins

### DIFF
--- a/codec.py
+++ b/codec.py
@@ -4,6 +4,8 @@ Separate from `solardevice` so plugins can import it without a cycle:
 `solardevice` imports plugins, never the reverse.
 """
 
+import logging
+
 # Two's-complement wrap points. A reading above the signed maximum is negative
 # and wraps by 2**bits. Every plugin open-coded this with its own constant and
 # each was short of 2**bits: Meritsun and Topband by one LSB (2**32 - 1),
@@ -25,3 +27,27 @@ def to_signed(value, wrap, threshold):
     practical bound rather than the arithmetic sign bit.
     """
     return value - wrap if value > threshold else value
+
+
+def ascii_hex_value(buf, start, end, default=0):
+    """Read an ASCII-hex field from `buf[start:end]` inclusive, low pair first.
+
+    The wire format writes each byte as two ASCII hex characters, least
+    significant pair first, so "0123" is 0x2301.
+
+    Truncated frames are the normal failure here, not an exceptional one: a
+    notification can be short or the framing can slip. Return `default` and say
+    so at debug rather than raising into the BLE callback (where it costs the
+    whole notification) or swallowing every exception silently (where it hides
+    real bugs).
+    """
+    if start < 0 or end < start or end >= len(buf):
+        logging.debug("field [%d:%d] outside a frame of %d bytes", start, end, len(buf))
+        return default
+    chars = [chr(c) for c in buf[start:end + 1]]
+    pairs = ["".join(pair) for pair in zip(chars[0::2], chars[1::2])]
+    try:
+        return int("".join(reversed(pairs)), 16)
+    except ValueError:
+        logging.debug("field [%d:%d] is not ASCII-hex: %r", start, end, "".join(chars))
+        return default

--- a/plugins/Meritsun/__init__.py
+++ b/plugins/Meritsun/__init__.py
@@ -9,7 +9,7 @@ from datetime import datetime
 # import duallog
 import logging
 
-from codec import INT32_MAX, UINT32_WRAP, to_signed
+from codec import INT32_MAX, UINT32_WRAP, ascii_hex_value, to_signed
 
 # duallog.setup('SmartPower', minLevel=logging.INFO)
 
@@ -61,13 +61,7 @@ class Util():
         self.prev_values = []
 
     def getValue(self, buf, start, end):
-        try:
-            # bytes = buf[0:8]
-            chars = list(map(chr, buf[start:end + 1]))
-            values = [ ''.join(x) for x in zip(chars[0::2], chars[1::2]) ]
-            return int("".join(reversed(values)), 16)
-        except Exception as e:
-            return 0
+        return ascii_hex_value(buf, start, end)
 
 
 

--- a/plugins/Topband/__init__.py
+++ b/plugins/Topband/__init__.py
@@ -9,7 +9,7 @@ from datetime import datetime
 # import duallog
 import logging
 
-from codec import INT32_MAX, UINT32_WRAP, to_signed
+from codec import INT32_MAX, UINT32_WRAP, ascii_hex_value, to_signed
 
 # duallog.setup('SmartPower', minLevel=logging.INFO)
 
@@ -41,24 +41,7 @@ class Util():
 
 
     def getValue(self, buf, start, end):
-        # Reads "start" -> "end" from "buf" and return the hex-characters in the correct order
-        string = buf[start:end + 1]
-        # logging.debug(string)
-        e = end + 1
-        b = end - 1
-        string = ""
-        while b >= start:
-            chrs = buf[b:e]
-            # logging.debug(chrs)
-            e = b
-            b = b - 2
-            string += chr(chrs[0]) + chr(chrs[1])
-            # logging.debug(string)
-        try: 
-            ret = int(string, 16)
-        except Exception as e:
-            ret = 0
-        return ret
+        return ascii_hex_value(buf, start, end)
 
 
     def asciitochar(self, a, b):

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -57,3 +57,50 @@ def test_threshold_is_practical_not_arithmetic():
     assert SIGN_THRESHOLD == 255
     assert to_signed(300.0, CURRENT_WRAP, SIGN_THRESHOLD) < 0
     assert UINT16_WRAP // 2 - 1 != SIGN_THRESHOLD
+
+
+# --- ascii_hex_value -------------------------------------------------------
+
+from codec import ascii_hex_value
+
+FRAME = [ord(c) for c in "0123456789AB"]
+
+
+@pytest.mark.parametrize(
+    ("start", "end", "expected"),
+    [(0, 3, 0x2301), (0, 7, 0x67452301), (4, 11, 0xAB896745)],
+)
+def test_ascii_hex_reads_low_pair_first(start, end, expected):
+    assert ascii_hex_value(FRAME, start, end) == expected
+
+
+@pytest.mark.parametrize(
+    ("start", "end"),
+    [(0, 12), (10, 40), (12, 15), (-1, 3)],
+)
+def test_truncated_frame_returns_default_instead_of_raising(start, end):
+    """Topband used to raise IndexError here, straight into the BLE callback."""
+    assert ascii_hex_value(FRAME, start, end) == 0
+
+
+def test_default_is_configurable():
+    assert ascii_hex_value(FRAME, 0, 40, default=None) is None
+
+
+def test_non_hex_payload_returns_default():
+    assert ascii_hex_value([ord(c) for c in "ZZZZ"], 0, 3) == 0
+
+
+def test_end_before_start_is_rejected():
+    assert ascii_hex_value(FRAME, 6, 2) == 0
+
+
+def test_plugins_agree_with_the_shared_accessor():
+    """Meritsun and Topband hand-rolled this identically; both now delegate."""
+    from plugins.Meritsun import Util as Meritsun
+    from plugins.Topband import Util as Topband
+
+    for start, end in ((0, 3), (0, 7), (4, 11)):
+        expected = ascii_hex_value(FRAME, start, end)
+        assert Meritsun.getValue(None, FRAME, start, end) == expected
+        assert Topband.getValue(None, FRAME, start, end) == expected


### PR DESCRIPTION
Next Tier-1 item from #46: one bounds-checked frame accessor.

## What's actually there
Meritsun and Topband hand-rolled the same read — an ASCII-hex field, least-significant pair first. They agree exactly on well-formed input (verified across three ranges), and diverge on truncated frames:

```
field [8:19] of a 12-byte frame
  Topband  -> IndexError, out of the plugin and into notify_callback
  Meritsun -> 43913          <- a fabricated value
```

**Meritsun is the more dangerous of the two.** Its `except Exception: return 0` only reaches 0 when the field is missing entirely. Partially truncate it and the slice silently shortens, the surviving pairs parse as valid hex, and a plausible wrong number gets published — exactly the "silently-wrong data" this issue is about.

## Two corrections to the issue text
- **Hacien cannot raise.** It defines a `getValue`, but there are no call sites anywhere in the repo. Left alone rather than fixed.
- **Topband's IndexError doesn't reach the BLE stack.** `SolarDevice.notify_callback` has wrapped the handler since #54, so the cost is one dropped notification and a logged error, not a crash.

## The fix
`codec.ascii_hex_value(buf, start, end, default=0)` bounds-checks explicitly, returns the caller's default, and logs at debug which field and frame length were involved. Both plugins delegate to it; their `getValue` methods stay, so no call site changes.

Truncation is a normal event on a BLE notification stream, not an exceptional one. It should neither cost the whole notification nor be indistinguishable from real data.

## Tests
11 new cases in `tests/test_codec.py`: the low-pair-first decoding at three ranges, four out-of-bounds shapes (past the end, entirely past, negative start, end before start), a configurable default, non-hex payloads, and a check that both plugins now produce the same values as the shared accessor. Full suite 71 passing.
