### PR TITLE
Don't let the maxdiff guard latch an entity for ever

### DIFF
--- a/solardevice.py
+++ b/solardevice.py
@@ -208,6 +208,10 @@ class SolarDevice:
 
 
 class PowerDevice():
+    # How many consistent out-of-maxdiff readings to reject before believing the
+    # device. Guards against a stale stored value latching an entity for ever.
+    MAX_CONSECUTIVE_REJECTS = 2
+
     '''
     General class for different PowerDevices
     Stores the values read from the devices with the best available resolution (milli-whatever)
@@ -618,9 +622,30 @@ class PowerDevice():
             logging.warning("[{}] Value of {} out of bands: Changed from {} to {} (< min {})".format(self.name, var, definition['val'], val, definition['min']))
             return False
         if (definition['val'] != 0 and definition['val'] != 2731) and abs(val - definition['val']) > definition['maxdiff']:
-            logging.warning("[{}] Value of {} out of bands: Changed from {} to {} (> maxdiff {})".format(self.name, var, definition['val'], val, definition['maxdiff']))
-            return False
+            # A spurious reading is transient; a real change persists. Reject the
+            # first few, then believe the device. Rejecting for ever latches the
+            # entity: charge_cycles is monotonic with maxdiff 1, so a single
+            # missed notification puts every later reading out of band and the
+            # value never moves again.
+            #
+            # Only readings consistent with each other count towards the escape,
+            # so scattered noise still never gets through.
+            previous = definition.get('rejected_val')
+            if previous is not None and abs(val - previous) <= definition['maxdiff']:
+                definition['rejected'] = definition.get('rejected', 0) + 1
+            else:
+                definition['rejected'] = 1
+            definition['rejected_val'] = val
+            if definition['rejected'] <= self.MAX_CONSECUTIVE_REJECTS:
+                logging.warning("[{}] Value of {} out of bands: Changed from {} to {} (> maxdiff {}, rejected {}/{})".format(
+                    self.name, var, definition['val'], val, definition['maxdiff'],
+                    definition['rejected'], self.MAX_CONSECUTIVE_REJECTS + 1))
+                return False
+            logging.warning("[{}] Value of {} accepted after {} consistent readings out of band: {} -> {}".format(
+                self.name, var, definition['rejected'], definition['val'], val))
         logging.debug("[{}] Value of {} changed from {} to {}".format(self.name, var, definition['val'], val))
+        definition['rejected'] = 0
+        definition['rejected_val'] = None
         self.__dict__[var]['val'] = val
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,72 @@
+"""`PowerDevice.validate` bounds checking and the un-latching escape.
+
+The maxdiff guard rejects readings that jump further than physically plausible.
+Rejecting for ever latches the entity: `charge_cycles` is monotonic with
+maxdiff 1, so one missed notification made every later reading out of band and
+the value never moved again.
+"""
+
+import pytest
+
+from solardevice import BatteryDevice
+
+
+class _Parent:
+    """`PowerDevice.name` is a read-only property reading through to the parent."""
+    logger_name = "test-pack"
+
+
+@pytest.fixture
+def device():
+    return BatteryDevice(parent=_Parent())
+
+
+def set_cycles(dev, value):
+    """validate() returns False on reject, None on accept."""
+    return dev.validate('_charge_cycles', value) is None
+
+
+def test_normal_increment_is_accepted(device):
+    device._charge_cycles['val'] = 63
+    assert set_cycles(device, 64)
+    assert device._charge_cycles['val'] == 64
+
+
+def test_a_jump_is_rejected_first(device):
+    device._charge_cycles['val'] = 63
+    assert not set_cycles(device, 65)
+    assert device._charge_cycles['val'] == 63
+
+
+def test_a_persistent_jump_is_eventually_believed(device):
+    """The wedge: 64 was missed, so the pack now reports 65 for ever."""
+    device._charge_cycles['val'] = 63
+    assert not set_cycles(device, 65)
+    assert not set_cycles(device, 65)
+    assert set_cycles(device, 65)          # believed on the third
+    assert device._charge_cycles['val'] == 65
+
+
+def test_scattered_noise_is_never_believed(device):
+    device._charge_cycles['val'] = 63
+    for spurious in (400, 9000, 120, 7777, 250, 3000):
+        assert not set_cycles(device, spurious)
+    assert device._charge_cycles['val'] == 63
+
+
+def test_the_counter_resets_after_an_accepted_value(device):
+    device._charge_cycles['val'] = 63
+    assert not set_cycles(device, 65)      # one rejection banked
+    assert set_cycles(device, 64)          # normal reading accepted
+    assert not set_cycles(device, 66)      # ...so this starts from scratch
+    assert not set_cycles(device, 66)
+    assert set_cycles(device, 66)
+
+
+def test_hard_bounds_are_never_escaped(device):
+    """min/max are physical limits, not rate limits -- no escape from them."""
+    device._charge_cycles['val'] = 63
+    for _ in range(5):
+        assert not set_cycles(device, 99999)   # above max
+        assert not set_cycles(device, -1)      # below min
+    assert device._charge_cycles['val'] == 63


### PR DESCRIPTION
Next Tier-1 item from #46: the `validate()` latch.

## The bug
The maxdiff guard rejects readings that jump further than physically plausible — but it compares against a stored value that it then never updates. `_charge_cycles` is monotonic with `maxdiff: 1`, so:

```
stored 63, pack reports 64   -> accepted
stored 63, notification lost
stored 63, pack reports 65   -> |65-63| = 2 > 1, rejected
stored 63, pack reports 65   -> rejected
...for ever
```

One missed notification and the entity is stuck until a restart.

## The fix
A spurious reading is transient; a real change persists. Reject the first two, then believe the device.

Only readings **consistent with each other** count towards the escape — each rejection must be within `maxdiff` of the previous one — so scattered noise still never gets through. `MAX_CONSECUTIVE_REJECTS` is a class attribute on `PowerDevice`, so it is one place to change and easy to test.

`min`/`max` are deliberately **not** escapable. They are physical bounds, not rate limits.

## Relationship to #27
They look adjacent but do not overlap, and this PR does not close #27.

- This changes the **rate limit** (`maxdiff`): how fast a value may move.
- #27 is about the **hard bounds** (`min`/`max`) being wrong for hardware the defaults never anticipated — a Rover 60 with two 24 V panels in series hits nearly 70 V input, above the shipped `max`.

No escape hatch can fix that: a reading above `max` is rejected on the first sample and every one after, by design. #27 needs the bounds to be configurable, which is a separate change with a config-format decision attached.

## Tests
`tests/test_validate.py`, 6 cases: a normal increment, a first jump rejected, a persistent jump believed on the third reading, scattered noise never believed, the counter resetting after any accepted value, and hard bounds never escaping. The two escape cases fail on `master`; the other four pass on both, so nothing else moved. Full suite 77 passing.
