### PR TITLE
Tune validation limits per device from the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,50 @@ The systemd unit file might need some adjustments to point to the right scripts
 Alternatively just run `solar-monitor.py` in something like termux or screen (might require root privileges to access bluetooth directly)
 
 
+# Tuning the value limits
+
+Every reading is checked against bounds before it is published: a hard `min` and
+`max`, and a `maxdiff` limiting how far a value may move between readings. This
+is deliberate — these devices report occasional nonsense, and an unfiltered spike
+shows up as a dip in your graphs or a false alert.
+
+The shipped defaults suit the hardware this was written against. Other hardware
+legitimately exceeds them: two 24 V panels in series reach nearly 70 V, well past
+the default input-voltage ceiling, and every reading is then rejected as out of
+bands with a warning in the log.
+
+Override any bound in that device's own section. The option is the value's name
+followed by `_min`, `_max` or `_maxdiff`:
+
+```ini
+[regulator]
+type = SolarLink
+mac = 11:11:11:11:11:11
+input_mvoltage_max = 96000       # 96 V panel input instead of the default
+input_mvoltage_maxdiff = 48000
+```
+
+Values are stored at the best available resolution, so **the units are milli-**
+**whatever**: millivolts, milliamps, milliwatts. Temperature is /10 kelvin and
+soc is /10 %. `96000` above is 96 V.
+
+Tunable names, depending on device type:
+
+| | |
+|---|---|
+| voltage | `mvoltage`, `input_mvoltage`, `charge_mvoltage` |
+| current | `mcurrent`, `input_mcurrent`, `charge_mcurrent` |
+| power | `mpower`, `input_mpower`, `charge_mpower` |
+| capacity | `mcapacity`, `max_capacity`, `exp_capacity` |
+| other | `dsoc`, `dkelvin`, `bkelvin`, `charge_cycles` |
+
+Each override is logged at startup, so `Changed input_mvoltage max: 48000 -> 96000`
+in the log confirms it was picked up. An unparseable value is ignored with a
+warning and the default kept.
+
+If a reading is rejected but you believe the device, the log line names the value,
+the bound and both numbers — that tells you which option to set and to what.
+
 # Output
 ```
 2020-06-22 13:34:09,149 INFO    : Adapter status - Powered: True

--- a/solar-monitor.ini.dist
+++ b/solar-monitor.ini.dist
@@ -47,6 +47,10 @@ persistent = True
 [regulator]
 type = SolarLink
 mac = 11:11:11:11:11:11
+# Validation bounds can be tuned per device when the defaults do not fit your
+# hardware -- see "Tuning the value limits" in the README. Units are milli-
+# whatever, so this is a 96 V panel input:
+# input_mvoltage_max = 96000
 reconnect = False
 # Hold every device connected continuously (recommended). See [monitor] above.
 persistent = True

--- a/solardevice.py
+++ b/solardevice.py
@@ -79,6 +79,7 @@ class SolarDevice:
             self.entities = RectifierDevice(parent=self)
         else:
             self.entities = PowerDevice(parent=self)
+        self.entities.apply_limit_overrides(config, logger_name)
         self.util = self.module.Util(self)
 
     def alias(self):
@@ -608,6 +609,41 @@ class PowerDevice():
                 out = "{} {} == {},".format(out, var, self.__dict__[var])
         logging.debug(out)
 
+
+    LIMIT_KEYS = ('min', 'max', 'maxdiff')
+
+    def apply_limit_overrides(self, config, section):
+        """Override validation bounds from the device's own config section.
+
+        The shipped defaults suit the hardware this was written against; other
+        hardware legitimately exceeds them -- two 24 V panels in series reach
+        nearly 70 V, well past the default input-voltage ceiling, and every
+        reading is then rejected as out of bands (#27).
+
+        A definition named `_input_mvoltage` is tuned with `input_mvoltage_max`,
+        `input_mvoltage_min` and `input_mvoltage_maxdiff`, in the same units the
+        device stores -- millivolts, milliamps, /10 kelvin, /10 %.
+        """
+        if not (config and section and config.has_section(section)):
+            return
+        for name, definition in list(self.__dict__.items()):
+            if not isinstance(definition, dict):
+                continue
+            if not all(key in definition for key in self.LIMIT_KEYS):
+                continue
+            for key in self.LIMIT_KEYS:
+                option = "{}_{}".format(name.lstrip('_'), key)
+                if not config.has_option(section, option):
+                    continue
+                try:
+                    value = config.getfloat(section, option)
+                except ValueError:
+                    logging.warning("[{}] {} is not a number; keeping {} = {}".format(
+                        section, option, key, definition[key]))
+                    continue
+                logging.info("[{}] {} {}: {} -> {}".format(
+                    section, name.lstrip('_'), key, definition[key], value))
+                definition[key] = value
 
     def validate(self, var, val):
         definition = getattr(self, var)

--- a/tests/test_limit_overrides.py
+++ b/tests/test_limit_overrides.py
@@ -1,0 +1,83 @@
+"""Per-device limit overrides from the config section (#27).
+
+The shipped bounds suit one set of hardware. A Rover 60 with two 24 V panels in
+series reaches nearly 70 V, above the default input-voltage ceiling, and every
+reading is then rejected as out of bands.
+"""
+
+import configparser
+
+import pytest
+
+from solardevice import RegulatorDevice
+
+
+class _Parent:
+    logger_name = "regulator"
+
+
+def make_config(**options):
+    config = configparser.ConfigParser()
+    config["regulator"] = {"type": "SolarLink", "mac": "aa:bb:cc:dd:ee:ff", **options}
+    return config
+
+
+@pytest.fixture
+def device():
+    return RegulatorDevice(parent=_Parent())
+
+
+def test_defaults_are_kept_without_overrides(device):
+    before = dict(device._input_mvoltage)
+    device.apply_limit_overrides(make_config(), "regulator")
+    assert device._input_mvoltage == before
+
+
+def test_max_is_overridden(device):
+    device.apply_limit_overrides(make_config(input_mvoltage_max="96000"), "regulator")
+    assert device._input_mvoltage["max"] == 96000
+
+
+def test_all_three_bounds_are_tunable(device):
+    device.apply_limit_overrides(
+        make_config(input_mvoltage_min="10", input_mvoltage_max="96000",
+                    input_mvoltage_maxdiff="48000"),
+        "regulator",
+    )
+    assert device._input_mvoltage["min"] == 10
+    assert device._input_mvoltage["max"] == 96000
+    assert device._input_mvoltage["maxdiff"] == 48000
+
+
+def test_an_overridden_ceiling_lets_the_reading_through(device):
+    """The point of the issue: 70 V input is rejected until max is raised."""
+    device._input_mvoltage["val"] = 60000
+    assert device.validate("_input_mvoltage", 70000) is False   # above the default max
+
+    device.apply_limit_overrides(make_config(input_mvoltage_max="96000"), "regulator")
+    assert device.validate("_input_mvoltage", 70000) is None    # accepted
+    assert device._input_mvoltage["val"] == 70000
+
+
+def test_unknown_options_are_ignored(device):
+    device.apply_limit_overrides(make_config(nonsense_max="1", type_max="2"), "regulator")
+    assert device._input_mvoltage["max"] != 1
+
+
+def test_a_non_numeric_override_keeps_the_default(device):
+    default = device._input_mvoltage["max"]
+    device.apply_limit_overrides(make_config(input_mvoltage_max="very high"), "regulator")
+    assert device._input_mvoltage["max"] == default
+
+
+def test_missing_section_is_harmless(device):
+    before = dict(device._input_mvoltage)
+    device.apply_limit_overrides(make_config(), "no-such-device")
+    device.apply_limit_overrides(None, "regulator")
+    assert device._input_mvoltage == before
+
+
+def test_cell_mvoltage_is_not_mistaken_for_a_limit_dict(device):
+    """`_cell_mvoltage` is a dict of cells, not a bounds definition."""
+    device.apply_limit_overrides(make_config(cell_mvoltage_max="9"), "regulator")
+    assert "max" not in device._cell_mvoltage


### PR DESCRIPTION
Fixes #27 — the bounds are tunable per device instead of requiring a patch to `solardevice.py`.

## The problem
Every reading is checked against `min`/`max`/`maxdiff` before publishing, which is what keeps these devices' occasional nonsense out of the graphs. But the shipped bounds suit one set of hardware. From the issue: a Rover 60 with two 24 V panels in series hits nearly 70 V input, above the default ceiling, so every reading is rejected as out of bands. The reporter's fix was to edit `solardevice.py` by hand.

## The change
Any bound can be overridden in that device's own config section, named after the value plus `_min`, `_max` or `_maxdiff`:

```ini
[regulator]
type = SolarLink
mac = 11:11:11:11:11:11
input_mvoltage_max = 96000
input_mvoltage_maxdiff = 48000
```

`PowerDevice.apply_limit_overrides()` walks the definitions the class actually declares, so it works for every device type without a mapping table, and `_cell_mvoltage` — a dict of cells rather than a bounds definition — is skipped by shape.

Units are what the device stores: milli-whatever, /10 kelvin, /10 %. Each override is logged at startup so you can confirm it was picked up; an unparseable value is ignored with a warning and the default kept.

## Documentation
A "Tuning the value limits" section in the README: why the limits exist at all, the naming rule, the units caveat, a table of tunable names by device type, and how to read a rejection warning to work out which option to set. A commented example on the regulator in `solar-monitor.ini.dist`.

## Relationship to #62
Complementary. #62 relaxed the **rate limit** so a stale stored value can no longer latch an entity for ever. This makes the **hard bounds** configurable — which no escape hatch could do, since a reading above `max` is rejected by design on every sample.

## Tests
`tests/test_limit_overrides.py`, 8 cases: defaults untouched without overrides, one and all three bounds overridden, the issue's own scenario end to end (70 V rejected at the default, accepted after raising `max`), unknown options ignored, a non-numeric value keeping the default, a missing section and a `None` config both harmless, and `_cell_mvoltage` not mistaken for a limits dict. Full suite 85 passing.
