### PR TITLE
Configured MQTT port crashed; topic registry grew without bound

### DIFF
--- a/datalogger.py
+++ b/datalogger.py
@@ -54,7 +54,10 @@ class DataLoggerMqtt():
         self.client.connect(broker, port)                                   # establish connection
         self.client.loop_start()                                            # start the loop
 
-        self.sensors = []
+        # A set, not a list: `publish(refresh=True)` re-appends an already-known
+        # topic, so this grew without bound -- 1000 entries for one unique topic
+        # on a long-running install -- and every publish paid a linear scan.
+        self.sensors = set()
         self.sets = {}
         if not prefix.endswith("/"):
             prefix = prefix + "/"
@@ -87,7 +90,7 @@ class DataLoggerMqtt():
                 # entities went missing after a container restart, which resets
                 # self.sensors and so re-ran this block for every entity.
                 self.create_sensor(device, var)
-            self.sensors.append(topic)
+            self.sensors.add(topic)
         logging.debug("Publishing to MQTT {}: {} = {}".format(self.broker, topic, val))
         # Switch state at QoS 1 so a toggle during a disconnect is delivered on
         # reconnect rather than silently dropped; high-frequency sensor state
@@ -307,7 +310,7 @@ class DataLogger():
                     device_types[section] = dtype
             self.mqtt = DataLoggerMqtt(
                 config.get('mqtt', 'broker'),
-                config.get('mqtt', 'port', fallback=1883),
+                config.getint('mqtt', 'port', fallback=1883),
                 prefix=config.get('mqtt', 'prefix', fallback=None),
                 username=config.get('mqtt', 'username', fallback=None),
                 password=config.get('mqtt', 'password', fallback=None),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,36 @@ def _install_paho_stub():
     mqtt = types.ModuleType("paho.mqtt")
     client = types.ModuleType("paho.mqtt.client")
 
+    class Client:
+        """Records what the code under test asked of the broker."""
+
+        def __init__(self, *args, **kwargs):
+            self.connected_to = None
+            self.published = []
+            self.subscribed = []
+
+        def username_pw_set(self, **kwargs):
+            pass
+
+        def connect(self, host, port):
+            if not isinstance(port, int):
+                # what real paho does: `if port <= 0` on a str
+                raise TypeError(
+                    "'<=' not supported between instances of "
+                    "'{}' and 'int'".format(type(port).__name__))
+            self.connected_to = (host, port)
+
+        def loop_start(self):
+            pass
+
+        def publish(self, topic, payload=None, qos=0, retain=False):
+            self.published.append((topic, payload, qos, retain))
+            return types.SimpleNamespace(rc=0, mid=1)
+
+        def subscribe(self, topic):
+            self.subscribed.append(topic)
+
+    client.Client = Client
     mqtt.client = client
     paho.mqtt = mqtt
 

--- a/tests/test_datalogger_mqtt.py
+++ b/tests/test_datalogger_mqtt.py
@@ -1,0 +1,43 @@
+"""MQTT datalogger: the configured port, and the topic-registry growth."""
+
+import configparser
+
+import pytest
+
+from datalogger import DataLogger
+
+
+def make_config(**mqtt):
+    config = configparser.ConfigParser()
+    config["mqtt"] = {"broker": "mqtt.example.net", "hostname": "test-host", **mqtt}
+    config["datalogger"] = {}
+    config["battery_1"] = {"type": "Meritsun", "mac": "11:11:11:11:11:11"}
+    return config
+
+
+def test_default_port_is_used_when_unset():
+    logger = DataLogger(make_config())
+    assert logger.mqtt.client.connected_to == ("mqtt.example.net", 1883)
+
+
+@pytest.mark.parametrize("configured", ["1883", "8883"])
+def test_a_configured_port_reaches_paho_as_an_int(configured):
+    """config.get returns a string, and paho does `if port <= 0` on it, so any
+    explicitly configured port -- even the default -- used to raise TypeError."""
+    logger = DataLogger(make_config(port=configured))
+    assert logger.mqtt.client.connected_to == ("mqtt.example.net", int(configured))
+
+
+def test_republishing_a_topic_does_not_grow_the_registry():
+    """`refresh=True` re-registered an already-known topic every time."""
+    logger = DataLogger(make_config())
+    for _ in range(50):
+        logger.mqtt.publish("battery_1", "voltage", 13.7, refresh=True)
+    assert len(logger.mqtt.sensors) == 1
+
+
+def test_distinct_topics_are_all_registered():
+    logger = DataLogger(make_config())
+    for var in ("voltage", "current", "soc"):
+        logger.mqtt.publish("battery_1", var, 1)
+    assert len(logger.mqtt.sensors) == 3


### PR DESCRIPTION
Two small datalogger items from #46.

## The port bug is broader than the issue says
`config.get('mqtt', 'port', fallback=1883)` returns a **string** for anything written in the ini, and paho validates with `if port <= 0`:

```
port=1883     connected
port='1883'   TypeError: '<=' not supported between instances of 'str' and 'int'
port='8883'   TypeError: '<=' not supported between instances of 'str' and 'int'
```

So it isn't only TLS or non-default ports — writing `port = 1883` explicitly crashes just as hard. Only the int fallback ever worked, which is why nobody hit it. `config.getint` fixes it.

## The topic registry grew without bound
`publish(..., refresh=True)` re-registered a topic already in `self.sensors` and appended it again, so the list grew for ever (the issue measured 1000 entries for one unique topic) and every publish paid a linear membership scan. `self.sensors` is now a `set`.

## Test infrastructure
Neither bug had coverage because `DataLogger` could not be constructed in tests at all — the conftest paho stub was a bare module with no `Client`. It now provides one that records connects, publishes and subscribes, and that raises `TypeError` on a non-int port exactly as real paho does.

That unlocks the remaining datalogger items in #46 (commit-after-send, publish return codes), which were equally untestable before.

## Tests
`tests/test_datalogger_mqtt.py`, 5 cases: the default port, a configured port arriving as an int (parametrised over `1883` and `8883`), 50 refresh publishes leaving one registry entry, and distinct topics all registered. Three fail on `master`. Full suite 90 passing.
