### PR TITLE
Remember a value as sent only once it has been

### DIFF
--- a/datalogger.py
+++ b/datalogger.py
@@ -99,6 +99,13 @@ class DataLoggerMqtt():
         ret = self.client.publish(topic, val, qos=qos, retain=True)
         if "power_switch" in var and time.time() > self._listener_created[device, var] + 300:
             self.create_listener(device, var)
+        # rc is MQTT_ERR_SUCCESS (0) once the message is queued for delivery;
+        # anything else (typically MQTT_ERR_NO_CONN) means it was dropped.
+        rc = getattr(ret, "rc", 0)
+        if rc != 0:
+            logging.warning("Publish to {} failed (rc={})".format(topic, rc))
+            return False
+        return True
 
     def _device_block(self, device):
         """The Home Assistant 'device' object shared by every entity of one
@@ -354,24 +361,35 @@ class DataLogger():
             self.logdata[device][var]['ts'] = ts
             self.logdata[device][var]['value'] = None
 
+        # Remember a value as sent only once it has been. Committing first meant
+        # a publish that failed -- a broker outage, a dropped link -- left the
+        # cache claiming the value was delivered, so the next identical reading
+        # compared equal and never resent it. The change then waited for the
+        # value to move again or for the 10-minute refresh.
         if self.logdata[device][var]['value'] != val:
-            self.logdata[device][var]['ts'] = ts
-            self.logdata[device][var]['value'] = val
             logging.info("[{}] Sending new data {}: {}".format(device, var, val))
-            self.send_to_server(device, var, val)
+            if self.send_to_server(device, var, val):
+                self.logdata[device][var]['ts'] = ts
+                self.logdata[device][var]['value'] = val
+            else:
+                logging.warning("[{}] {} = {} not delivered; will resend".format(device, var, val))
         elif self.logdata[device][var]['ts'] < datetime.now()-timedelta(minutes=10):
-            self.logdata[device][var]['ts'] = ts
-            self.logdata[device][var]['value'] = val
-            # logging.debug("Sending data to server due to long wait")
             logging.info("[{}] Sending refreshed data {}: {}".format(device, var, val))
-            self.send_to_server(device, var, val, True)
+            if self.send_to_server(device, var, val, True):
+                self.logdata[device][var]['ts'] = ts
+                self.logdata[device][var]['value'] = val
 
 
 
 
     def send_to_server(self, device, var, val, refresh=False):
+        """Return True only if every configured sink accepted the value.
+
+        The caller uses this to decide whether to remember the value as sent.
+        """
+        delivered = True
         if self.mqtt:
-            self.mqtt.publish(device, var, val, refresh)
+            delivered = self.mqtt.publish(device, var, val, refresh) and delivered
         if self.url:
             logging.info("[{}] Sending data to {}".format(device, self.url))
             ts = datetime.now().isoformat(' ', 'seconds')
@@ -379,8 +397,13 @@ class DataLogger():
             header = {'Content-type': 'application/json', 'Accept': 'text/plain', 'Authorization': 'Bearer {}'.format(self.token)}
             try:
                 response = requests.post(url=self.url, json=payload, headers=header, timeout=(5, 10))
+                if response.status_code >= 400:
+                    logging.error("POST to {} returned {}".format(self.url, response.status_code))
+                    delivered = False
             except requests.exceptions.RequestException as e:
                 logging.error("Failed to POST to {}: {}".format(self.url, e))
+                delivered = False
+        return delivered
 
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,10 @@ def _install_paho_stub():
             pass
 
         def publish(self, topic, payload=None, qos=0, retain=False):
+            # rc mirrors paho: 0 is MQTT_ERR_SUCCESS, 4 is MQTT_ERR_NO_CONN.
+            # Tests set `offline` to simulate a broker outage.
+            if getattr(self, "offline", False):
+                return types.SimpleNamespace(rc=4, mid=0)
             self.published.append((topic, payload, qos, retain))
             return types.SimpleNamespace(rc=0, mid=1)
 

--- a/tests/test_datalogger_delivery.py
+++ b/tests/test_datalogger_delivery.py
@@ -1,0 +1,68 @@
+"""A value is remembered as sent only once it has been.
+
+Committing to `logdata` before publishing meant a failed publish left the cache
+claiming delivery, so the next identical reading compared equal and was never
+resent.
+"""
+
+import configparser
+
+import pytest
+
+from datalogger import DataLogger
+
+
+def make_config():
+    config = configparser.ConfigParser()
+    config["mqtt"] = {"broker": "mqtt.example.net", "hostname": "test-host"}
+    config["datalogger"] = {}
+    return config
+
+
+@pytest.fixture
+def logger():
+    return DataLogger(make_config())
+
+
+def states(logger, var="voltage"):
+    return [p for p in logger.mqtt.client.published if p[0].endswith(f"/{var}/state")]
+
+
+def test_a_value_is_published_and_remembered(logger):
+    logger.log("battery_1", "voltage", 13.7)
+    assert len(states(logger)) == 1
+    assert logger.logdata["battery_1"]["voltage"]["value"] == 13.7
+
+
+def test_an_unchanged_value_is_not_republished(logger):
+    logger.log("battery_1", "voltage", 13.7)
+    logger.log("battery_1", "voltage", 13.7)
+    assert len(states(logger)) == 1
+
+
+def test_a_failed_publish_is_not_remembered(logger):
+    logger.mqtt.client.offline = True
+    logger.log("battery_1", "voltage", 13.7)
+    assert states(logger) == []
+    assert logger.logdata["battery_1"]["voltage"]["value"] is None
+
+
+def test_the_value_is_resent_once_the_broker_returns(logger):
+    """The bug: the same reading after an outage used to compare equal."""
+    logger.mqtt.client.offline = True
+    logger.log("battery_1", "voltage", 13.7)
+    logger.mqtt.client.offline = False
+    logger.log("battery_1", "voltage", 13.7)
+    assert len(states(logger)) == 1
+    assert logger.logdata["battery_1"]["voltage"]["value"] == 13.7
+
+
+def test_a_switch_state_survives_an_outage(logger):
+    """Worst case: a toggle during an outage is the change you least want lost."""
+    logger.log("regulator", "power_switch", "ON")
+    logger.mqtt.client.offline = True
+    logger.log("regulator", "power_switch", "OFF")
+    logger.mqtt.client.offline = False
+    logger.log("regulator", "power_switch", "OFF")
+    published = [p[1] for p in states(logger, "power_switch")]
+    assert published == ["ON", "OFF"]


### PR DESCRIPTION
Next datalogger item from #46: commit `logdata` only after a successful send, and check publish return codes.

## The bug
`log()` wrote the new value into `logdata` **and then** published it:

```python
if self.logdata[device][var]['value'] != val:
    self.logdata[device][var]['value'] = val   # committed first
    self.send_to_server(device, var, val)      # ...then sent, result ignored
```

If the publish failed, the cache still claimed the value had been delivered. The next identical reading compared equal and was never resent. The change then waited either for the value to move again or for the 10-minute refresh — so a reading taken during a broker blip is stale in Home Assistant long after the broker is back.

It is worst on a switch. Toggle the regulator during an outage and HA keeps showing the old state until something unrelated changes; `power_switch` publishes at QoS 1 precisely because that state matters, but QoS cannot help a message that was never queued.

## The change
- `DataLoggerMqtt.publish()` returns whether the broker accepted the message — paho's `rc`, where 0 is `MQTT_ERR_SUCCESS` and 4 is `MQTT_ERR_NO_CONN` — and logs the failure.
- The HTTP sink reports `>= 400` responses as well as request exceptions, which were previously caught and dropped.
- `send_to_server()` returns True only if **every** configured sink accepted.
- `log()` commits to `logdata` on success and leaves the previous value in place otherwise, so the next reading resends.

## Correction to the issue text
"lost permanently" is a shade strong: the 10-minute refresh branch does eventually resend the current value. What is lost is the *transition* and up to ten minutes of freshness — still worth fixing, particularly for switch state.

## Tests
`tests/test_datalogger_delivery.py`, 5 cases: a value published and remembered, an unchanged value not republished, a failed publish not remembered, the same reading resent once the broker returns, and a switch toggle during an outage arriving as `["ON", "OFF"]` rather than just `["ON"]`. Three fail on `master`.

The conftest paho stub gained an `offline` flag returning `rc=4`, which is how a broker outage is simulated. Full suite 95 passing.
