### PR TITLE
Delete the shadowed _mvoltage that capped regulators at 12 V

### DIFF
--- a/solardevice.py
+++ b/solardevice.py
@@ -261,6 +261,9 @@ class PowerDevice():
             'max': 200000,
             'maxdiff': 100000
         }
+        # 48 V, matching _input_mvoltage and _charge_mvoltage. Subclasses that
+        # know their system voltage narrow it: BatteryDevice to 10-15 V,
+        # RectifierDevice to 50 V, InverterDevice to 250 V.
         self._mvoltage = {
             'val': 0,
             'min': 0,
@@ -302,12 +305,6 @@ class PowerDevice():
             'min': 0,
             'max': 48000,
             'maxdiff': 12000
-        }
-        self._mvoltage = {
-            'val': 0,
-            'min': 0,
-            'max': 15000,
-            'maxdiff': 15000
         }
         self._msg = None
         self._status = None

--- a/tests/test_device_limits.py
+++ b/tests/test_device_limits.py
@@ -1,0 +1,72 @@
+"""Each device class's effective validation bounds.
+
+`PowerDevice.__init__` defined `_mvoltage` twice — 48 V at its structural
+position, then 15 V appended at the end of the block, which silently won. The
+15 V value was a 12 V assumption that got its proper home in `BatteryDevice`
+three days later (2020-06-29 c43473a, 2020-07-02 dcad6bf) and was left behind
+in the base. `RegulatorDevice` never overrides, so it inherited the 12 V cap and
+rejected every reading on a 24 V or 48 V system.
+
+These assertions are cheap and would have caught a shadowed definition.
+"""
+
+import pytest
+
+from solardevice import (BatteryDevice, InverterDevice, PowerDevice,
+                         RectifierDevice, RegulatorDevice)
+
+
+class _Parent:
+    logger_name = "test-device"
+
+
+@pytest.mark.parametrize(
+    ("cls", "expected_max"),
+    [
+        (PowerDevice, 48000),       # 48 V, as its sibling voltages
+        (RegulatorDevice, 48000),   # inherits; must cover 24 V and 48 V systems
+        (BatteryDevice, 15000),     # a 12 V pack, declared on the subclass
+        (RectifierDevice, 50000),
+        (InverterDevice, 250000),
+    ],
+)
+def test_effective_voltage_ceiling(cls, expected_max):
+    assert cls(parent=_Parent())._mvoltage["max"] == expected_max
+
+
+def test_a_24v_regulator_reading_is_accepted():
+    """The bug: 29 V on a 24 V bank was rejected by the inherited 12 V cap."""
+    regulator = RegulatorDevice(parent=_Parent())
+    assert regulator.validate("_mvoltage", 29000) is None
+    assert regulator._mvoltage["val"] == 29000
+
+
+def test_a_48v_bank_still_needs_an_override():
+    """Known limit, deliberately pinned.
+
+    "48 V" is a nominal system voltage; such a bank charges to 54-58 V, above
+    this ceiling. Deleting the shadowed definition fixes 12 V and 24 V systems.
+    A 48 V one still needs `mvoltage_max` in its config section (#27/#63).
+    """
+    regulator = RegulatorDevice(parent=_Parent())
+    assert regulator.validate("_mvoltage", 58000) is False
+
+
+def test_a_battery_still_rejects_an_impossible_reading():
+    """Narrowing on the subclass must survive: a 12 V pack is not 52 V."""
+    battery = BatteryDevice(parent=_Parent())
+    assert battery.validate("_mvoltage", 52000) is False
+
+
+def test_powerdevice_bounds_are_all_real_rate_limits():
+    """Every bound the base declares has maxdiff < max.
+
+    That was the tell that the deleted definition was a draft: at 15000/15000
+    it was the only entry here where the two were equal, permitting any jump
+    inside range. (RectifierDevice and InverterDevice do use maxdiff == max on
+    their own overrides, so this is a property of the base block, not the file.)
+    """
+    base = PowerDevice(parent=_Parent())
+    for name, definition in base.__dict__.items():
+        if isinstance(definition, dict) and {"min", "max", "maxdiff"} <= set(definition):
+            assert definition["maxdiff"] < definition["max"], name


### PR DESCRIPTION
The `_mvoltage` double-assignment from #46 — with the history that explains it.

## What it is
`PowerDevice.__init__` defines `_mvoltage` twice. The second wins:

```
line 264   max 48000  maxdiff 12000    2020-06-20  933f2f2
line 306   max 15000  maxdiff 15000    2020-06-29  c43473a   <- silently wins
```

`InverterDevice` (250 V) and `RectifierDevice` (50 V) override it, `BatteryDevice` declares 10–15 V, but **`RegulatorDevice` never overrides** — so a regulator inherited a 12 V ceiling and had every voltage reading on a 24 V bank rejected as out of bands.

## Why the second one exists
`git blame` dates it precisely:

- **2020-06-29** `c43473a` "Complete restructure" adds the families block — `_input_mvoltage` and `_charge_mvoltage` at 48000/12000, and a second `_mvoltage` at 15000/15000 appended after them.
- **2020-07-02** `dcad6bf`, three days later, gives `BatteryDevice` its own `_mvoltage` at min 10000 / max 15000.

So the 15 V value was a 12 V assumption that got its proper home on the subclass three days later. The draft in the base was never removed. Two further signals agree: line 264 sits at the structural position that completes the plain family in the same order the other two follow, and 15000/15000 was the only bound in the base where `maxdiff == max` — permitting any jump inside range, which is not a rate limit at all.

## The change
Delete the leftover. Nothing else moves:

| class | ceiling |
|---|---|
| PowerDevice | 48 V (matches its sibling voltages) |
| RegulatorDevice | 48 V (inherits) |
| BatteryDevice | 15 V (its own, 2020-07-02) |
| RectifierDevice / InverterDevice | 50 V / 250 V (unchanged) |

## Known limit, deliberately pinned
"48 V" is a *nominal* system voltage — such a bank charges to 54–58 V, above this ceiling. This fixes **12 V and 24 V** systems; a 48 V one still needs `mvoltage_max` in its config section, which #63 made possible. There is a test asserting that, so the limit is documented rather than discovered.

## Tests
`tests/test_device_limits.py`, 9 cases: the effective ceiling for all five classes, a 24 V reading accepted, a 48 V bank still rejected by default, a battery still rejecting an impossible reading, and every bound in the base having `maxdiff < max`. Four fail on `master`. Full suite 104 passing.
