### PR TITLE
Configurable resend interval for unchanged values

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ The systemd unit file might need some adjustments to point to the right scripts
 Alternatively just run `solar-monitor.py` in something like termux or screen (might require root privileges to access bluetooth directly)
 
 
+# Resend interval
+
+A value is published when it changes. A value that has *not* changed is resent
+every 10 minutes, so consumers that treat a long gap as a stale sensor stay
+happy. Set it per install in the `[datalogger]` section:
+
+```ini
+[datalogger]
+refresh = 30
+```
+
+Minutes. A longer interval means less traffic; a shorter one keeps graphs and
+external loggers from complaining when a value is genuinely steady. It applies
+to MQTT publishing as well as the HTTP datalogger.
+
 # Tuning the value limits
 
 Every reading is checked against bounds before it is published: a hard `min` and

--- a/datalogger.py
+++ b/datalogger.py
@@ -306,6 +306,10 @@ class DataLogger():
         logging.debug("Creating new DataLogger")
         self.url = None
         self.mqtt = None
+        # How often to resend a value that has not changed. Some consumers treat
+        # a long gap as a stale sensor, so this is a trade between traffic and
+        # keeping graphs and external loggers happy.
+        self.refresh_interval = config.getint('datalogger', 'refresh', fallback=10)
         if config.get('datalogger', 'url', fallback=None):
             self.url = config.get('datalogger', 'url')
             self.token = config.get('datalogger', 'token')
@@ -373,7 +377,7 @@ class DataLogger():
                 self.logdata[device][var]['value'] = val
             else:
                 logging.warning("[{}] {} = {} not delivered; will resend".format(device, var, val))
-        elif self.logdata[device][var]['ts'] < datetime.now()-timedelta(minutes=10):
+        elif self.logdata[device][var]['ts'] < datetime.now()-timedelta(minutes=self.refresh_interval):
             logging.info("[{}] Sending refreshed data {}: {}".format(device, var, val))
             if self.send_to_server(device, var, val, True):
                 self.logdata[device][var]['ts'] = ts

--- a/solar-monitor.ini.dist
+++ b/solar-monitor.ini.dist
@@ -72,6 +72,10 @@ reconnect = False
 # JSON/HTTP datalogger. Leave commented out to use MQTT only.
 # url = https://server.example.com/solar/api/
 # token = your-token-here
+# How often (in minutes) to resend a value that has not changed. A longer
+# interval means less traffic, but some graphs and external loggers complain
+# about stale data when updates are rare. Applies to MQTT as well as HTTP.
+refresh = 10
 
 [mqtt]
 # Address to the mqtt broker

--- a/tests/test_refresh_interval.py
+++ b/tests/test_refresh_interval.py
@@ -1,0 +1,60 @@
+"""The resend interval for values that have not changed.
+
+Lived on the `refresh-interval` branch, which never worked: it assigned
+`refresh_inteval` and read `refresh_interval`, so the first refresh check
+raised AttributeError, and `config.get` fed a string into `timedelta`.
+"""
+
+import configparser
+from datetime import datetime, timedelta
+
+import pytest
+
+from datalogger import DataLogger
+
+
+def make_config(**datalogger):
+    config = configparser.ConfigParser()
+    config["mqtt"] = {"broker": "mqtt.example.net", "hostname": "test-host"}
+    config["datalogger"] = dict(datalogger)
+    return config
+
+
+def states(logger, var="voltage"):
+    return [p for p in logger.mqtt.client.published if p[0].endswith(f"/{var}/state")]
+
+
+def test_default_interval_is_ten_minutes():
+    assert DataLogger(make_config()).refresh_interval == 10
+
+
+def test_a_configured_interval_is_an_int():
+    """config.get would hand timedelta a string and raise TypeError."""
+    logger = DataLogger(make_config(refresh="45"))
+    assert logger.refresh_interval == 45
+    assert isinstance(logger.refresh_interval, int)
+
+
+def test_an_unchanged_value_is_not_resent_before_the_interval():
+    logger = DataLogger(make_config(refresh="30"))
+    logger.log("battery_1", "voltage", 13.7)
+    logger.logdata["battery_1"]["voltage"]["ts"] = datetime.now() - timedelta(minutes=20)
+    logger.log("battery_1", "voltage", 13.7)
+    assert len(states(logger)) == 1
+
+
+def test_an_unchanged_value_is_resent_after_the_interval():
+    logger = DataLogger(make_config(refresh="30"))
+    logger.log("battery_1", "voltage", 13.7)
+    logger.logdata["battery_1"]["voltage"]["ts"] = datetime.now() - timedelta(minutes=31)
+    logger.log("battery_1", "voltage", 13.7)
+    assert len(states(logger)) == 2
+
+
+def test_the_refresh_path_does_not_raise():
+    """The branch's typo made exactly this call raise AttributeError."""
+    logger = DataLogger(make_config())
+    logger.log("battery_1", "voltage", 13.7)
+    logger.logdata["battery_1"]["voltage"]["ts"] = datetime.now() - timedelta(minutes=11)
+    logger.log("battery_1", "voltage", 13.7)          # must not raise
+    assert len(states(logger)) == 2


### PR DESCRIPTION
Takes the intent of the `refresh-interval` branch from #46. Reimplemented on `master` rather than merged — see below.

## What it does
A value is published when it changes; an unchanged value is resent every 10 minutes so consumers that treat a long gap as a stale sensor stay happy. That interval is now configurable:

```ini
[datalogger]
refresh = 30
```

Applies to MQTT publishing as well as the HTTP datalogger.

## Why not merge the branch
It has never worked, and cannot be merged as it stands:

```python
self.refresh_inteval = config.get('datalogger', 'refresh', fallback=10)   # set
... timedelta(minutes=self.refresh_interval)                              # read
```

The names differ, so the first refresh check raises `AttributeError` — and with the spelling fixed, `config.get` returns a string and `timedelta(minutes="10")` raises `TypeError`. Either way the consumer dies the first time a value goes ten minutes without changing, which is the Phase 1 deadlock the issue refers to.

It is also **65 commits behind** and conflicts in both files it touches. Its `log()` predates #65, so a merge would revert the commit-after-send fix and start losing values during broker outages again.

So this carries the branch's intent and its `.dist` wording forward, with `getint`, the name spelled consistently, a README section, and tests. **The branch can be deleted** once this lands.

## Observation, not fixed here
`DataLogger.__init__` calls `config.get('datalogger', ...)` unconditionally, and configparser's `fallback` does not cover a missing *section* — only a missing option. So deleting the whole `[datalogger]` section raises `NoSectionError`, even though the `.dist` invites an MQTT-only setup by commenting out its contents. Pre-existing; this change adds no new exposure, but it wants a `has_section` guard at some point.

## Tests
`tests/test_refresh_interval.py`, 5 cases: the default of 10, a configured value arriving as an `int`, an unchanged value not resent at 20 minutes with the interval at 30, resent at 31, and the refresh path not raising — which is exactly what the branch's typo did. Full suite 109 passing.
