### PR TITLE
The datalogger token is optional

### DIFF
--- a/datalogger.py
+++ b/datalogger.py
@@ -305,6 +305,7 @@ class DataLogger():
         # config.get('datalogger', 'url'), config.get('datalogger', 'token')
         logging.debug("Creating new DataLogger")
         self.url = None
+        self.token = None
         self.mqtt = None
         # How often to resend a value that has not changed. Some consumers treat
         # a long gap as a stale sensor, so this is a trade between traffic and
@@ -312,7 +313,9 @@ class DataLogger():
         self.refresh_interval = config.getint('datalogger', 'refresh', fallback=10)
         if config.get('datalogger', 'url', fallback=None):
             self.url = config.get('datalogger', 'url')
-            self.token = config.get('datalogger', 'token')
+            # Optional: an ingest endpoint may not require auth, and a missing
+            # token used to raise NoOptionError at startup.
+            self.token = config.get('datalogger', 'token', fallback=None)
         if config.get('mqtt', 'broker', fallback=None):
             device_types = {}
             for section in config.sections():
@@ -398,7 +401,9 @@ class DataLogger():
             logging.info("[{}] Sending data to {}".format(device, self.url))
             ts = datetime.now().isoformat(' ', 'seconds')
             payload = {'device': device, var: val, 'ts': ts}
-            header = {'Content-type': 'application/json', 'Accept': 'text/plain', 'Authorization': 'Bearer {}'.format(self.token)}
+            header = {'Content-type': 'application/json', 'Accept': 'text/plain'}
+            if self.token:
+                header['Authorization'] = 'Bearer {}'.format(self.token)
             try:
                 response = requests.post(url=self.url, json=payload, headers=header, timeout=(5, 10))
                 if response.status_code >= 400:

--- a/tests/test_datalogger_http.py
+++ b/tests/test_datalogger_http.py
@@ -39,3 +39,53 @@ def test_connection_error_is_swallowed_not_raised(monkeypatch):
     dl = _make_url_only_logger()
     # Must NOT raise — a network blip must never propagate to the consumer loop.
     dl.send_to_server("reg", "voltage", 13.2)
+
+
+def _capture_post(monkeypatch, status=200):
+    """Record the kwargs of a successful POST."""
+    calls = {}
+
+    def fake_post(*args, **kwargs):
+        calls.update(kwargs)
+
+        class _R:
+            status_code = status
+        return _R()
+
+    monkeypatch.setattr(requests, "post", fake_post)
+    return calls
+
+
+def test_the_auth_header_is_sent_when_a_token_is_configured(monkeypatch):
+    calls = _capture_post(monkeypatch)
+    dl = _make_url_only_logger()
+    dl.token = "s3cret"
+    dl.send_to_server("reg", "voltage", 13.2)
+    assert calls["headers"]["Authorization"] == "Bearer s3cret"
+
+
+def test_no_auth_header_without_a_token(monkeypatch):
+    """'Bearer None' is worse than no header at all."""
+    calls = _capture_post(monkeypatch)
+    dl = _make_url_only_logger()
+    dl.token = None
+    dl.send_to_server("reg", "voltage", 13.2)
+    assert "Authorization" not in calls["headers"]
+
+
+def test_a_url_without_a_token_can_be_configured():
+    """`config.get('datalogger', 'token')` had no fallback, so a url without a
+    token raised NoOptionError at startup."""
+    import configparser
+    config = configparser.ConfigParser()
+    config["datalogger"] = {"url": "https://ingest.example.com/api/"}
+    dl = datalogger.DataLogger(config)
+    assert dl.url == "https://ingest.example.com/api/"
+    assert dl.token is None
+
+
+def test_no_datalogger_section_at_all():
+    import configparser
+    dl = datalogger.DataLogger(configparser.ConfigParser())
+    assert dl.url is None and dl.token is None
+    assert dl.refresh_interval == 10


### PR DESCRIPTION
Small fix, and a correction to something I put on #46 an hour ago.

## The correction first
I added a `has_section` item to #46 claiming that configparser's `fallback` covers a missing *option* but not a missing *section*, so deleting `[datalogger]` would raise `NoSectionError`. **That is wrong** — `fallback` covers both:

```
c.get("datalogger", "refresh", fallback=10)   -> 10      (no section present)
c.get("datalogger", "refresh")                -> NoSectionError
```

`NoSectionError` only fires when there is no fallback. No guard is needed, and I'll strike the item.

## What is actually there
Checking each `datalogger` read individually turned up one without a fallback:

```
getint("datalogger","refresh", fallback=10)  -> 10          safe
get("datalogger","url", fallback=None)       -> ...         safe
get("datalogger","url")                      -> ...         guarded by the line above
get("datalogger","token")                    -> NoOptionError: No option 'token'
```

So configuring a `url` without a `token` raises at startup. An ingest endpoint may legitimately not require auth.

## The change
- `token` reads with `fallback=None`.
- The `Authorization` header is sent only when a token is set — `Bearer None` is worse than no header.
- `self.token` is initialised next to `self.url`, so it exists whether or not the HTTP sink is configured.

## Tests
Four added to `tests/test_datalogger_http.py`: the auth header present with a token and absent without one, a `url` configured without a `token`, and a `DataLogger` built from a config with no `[datalogger]` section at all. Three fail on `master`. Full suite 113 passing.
