### PR TITLE
Serialise BLE writes per connection

### DIFF
--- a/ble.py
+++ b/ble.py
@@ -22,7 +22,12 @@ async def _hold(dev, client, stop_event, poll_interval, sleep):
                 if not isinstance(data, (bytes, bytearray, memoryview)):
                     data = bytearray(data)
                 try:
-                    await client.write_gatt_char(dev.device_write_characteristic_polling, data)
+                    lock = getattr(client, "_solar_write_lock", None)
+                    if lock is not None:
+                        async with lock:
+                            await client.write_gatt_char(dev.device_write_characteristic_polling, data)
+                    else:
+                        await client.write_gatt_char(dev.device_write_characteristic_polling, data)
                 except Exception as e:
                     logging.warning("[%s] poll write failed: %r", dev.logger_name, e)
                     break
@@ -104,6 +109,11 @@ class BleManager:
     def _client_factory(self, mac):
         client = BleakClient(mac, adapter=self.adapter) if self.adapter else BleakClient(mac)
         client._solar_loop = self.loop
+        # Poll writes (_hold) and command writes (SolarDevice.characteristic_write_value)
+        # are separate coroutines on this one loop, so they interleave at every
+        # await -- a command can start a write while a poll write is in flight on
+        # the same connection. Serialise them per client.
+        client._solar_write_lock = asyncio.Lock()
         return client
 
     def start(self):

--- a/solardevice.py
+++ b/solardevice.py
@@ -197,9 +197,15 @@ class SolarDevice:
             value = bytearray(value)
         loop = getattr(client, "_solar_loop", None) or asyncio.get_event_loop()
 
+        lock = getattr(client, "_solar_write_lock", None)
+
         async def _w():
             try:
-                await client.write_gatt_char(char_uuid, value)
+                if lock is not None:
+                    async with lock:
+                        await client.write_gatt_char(char_uuid, value)
+                else:
+                    await client.write_gatt_char(char_uuid, value)
             except Exception as e:
                 logging.warning("[{}] characteristic write failed: {}".format(self.logger_name, e))
         try:

--- a/tests/test_write_lock.py
+++ b/tests/test_write_lock.py
@@ -1,0 +1,85 @@
+"""Writes to one connection are serialised.
+
+Poll writes (`ble._hold`) and command writes
+(`SolarDevice.characteristic_write_value`) are separate coroutines on the same
+asyncio loop, so they interleave at every await: a command could start a write
+while a poll write was still in flight on the same connection.
+"""
+
+import asyncio
+
+import ble
+
+
+class _Client:
+    """Records overlap: how many writes were in flight at once."""
+
+    def __init__(self):
+        self.is_connected = True
+        self.concurrent = 0
+        self.max_concurrent = 0
+        self.writes = []
+        self._solar_write_lock = asyncio.Lock()
+
+    async def write_gatt_char(self, char, data):
+        self.concurrent += 1
+        self.max_concurrent = max(self.max_concurrent, self.concurrent)
+        await asyncio.sleep(0)          # a real write yields here
+        self.writes.append((char, bytes(data)))
+        self.concurrent -= 1
+
+
+class _Device:
+    logger_name = "test-device"
+    need_polling = True
+    device_write_characteristic_polling = "poll-char"
+
+    def get_poll_data(self):
+        return [1, 2, 3]
+
+
+async def _competing_writer(client, n):
+    """Stands in for command writes arriving while the poll loop runs."""
+    for _ in range(n):
+        async with client._solar_write_lock:
+            await client.write_gatt_char("cmd-char", b"\x01")
+
+
+def test_poll_and_command_writes_never_overlap():
+    client, dev = _Client(), _Device()
+
+    async def run():
+        stop = asyncio.Event()
+
+        async def stop_soon():
+            await asyncio.sleep(0.05)
+            stop.set()
+
+        await asyncio.gather(
+            ble._hold(dev, client, stop, 0.001, asyncio.sleep),
+            _competing_writer(client, 20),
+            stop_soon(),
+        )
+
+    asyncio.run(run())
+    assert client.writes, "no writes were issued"
+    assert client.max_concurrent == 1, (
+        f"{client.max_concurrent} writes were in flight at once")
+
+
+def test_a_client_without_a_lock_still_writes():
+    """The lock is looked up defensively; absence must not break writing."""
+    client, dev = _Client(), _Device()
+    del client._solar_write_lock
+
+    async def run():
+        stop = asyncio.Event()
+
+        async def stop_soon():
+            await asyncio.sleep(0.02)
+            stop.set()
+
+        await asyncio.gather(ble._hold(dev, client, stop, 0.001, asyncio.sleep), stop_soon())
+
+    asyncio.run(run())
+    assert client.writes


### PR DESCRIPTION
The write-lock half of the write-lock item in #46.

## Why it is still needed after the bleak migration
Two coroutines write to the same connection, on the same loop:

- `ble._hold` — the poll write, `await client.write_gatt_char(...)`
- `SolarDevice.characteristic_write_value` — command writes, scheduled with `run_coroutine_threadsafe`

They interleave at every await. `_hold` suspends inside `write_gatt_char`, and a command that arrives meanwhile issues its own write on the same client. In the gatt era this surfaced as the `In Progress` error the issue mentions; with bleak, two concurrent `write_gatt_char` calls on one client are simply not something to rely on.

## The change
Each client gets an `asyncio.Lock` alongside its `_solar_loop`, and both write paths take it. It is looked up with `getattr`, so a client constructed without one still writes rather than failing — the existing `test_ble.py` fakes do exactly that.

## Not included
The other half of that checklist item — passing a failed payload back through the callback so it can be retried — is left out deliberately. The old retry path was dead code (`if error == "In Progress"` compared an exception to a string), so there is nothing to restore, and whether to retry a failed BLE write at all is a design question: a stale poll payload is usually better dropped than resent, while a command probably does want one attempt. That deserves its own change and its own decision.

## Tests
`tests/test_write_lock.py`, 2 cases. The first runs the real `_hold` against a fake client that counts writes in flight, with a competing command writer, and asserts the maximum concurrency is 1 — it fails on `master` with the writes overlapping. The second checks a client with no lock still writes.

Written with `asyncio.run()` in a sync test, following `test_ble.py`, so CI needs no new dependency. Full suite 115 passing.
