### PR TITLE
Retry a failed command write once, never a poll write

### DIFF
--- a/connection.py
+++ b/connection.py
@@ -10,6 +10,8 @@ The thread-based connection loops that used to live here (`maintain_device`,
 asyncio `maintain_device` in `ble.py` (bleak-based), which imports
 `backoff_seconds` from this module.
 """
+import asyncio
+import logging
 import random
 
 _MAX_BACKOFF_EXP = 30   # clamp the exponent so backoff can't grow to a bigint
@@ -26,3 +28,33 @@ def backoff_seconds(attempt, base=10.0, maximum=300.0, jitter=5.0, rand=None):
     attempt = min(max(attempt, 1), _MAX_BACKOFF_EXP)
     delay = min(base * (2 ** (attempt - 1)), maximum)
     return max(delay + rand(-jitter, jitter), 0.0)
+
+
+async def write_with_retry(client, char_uuid, value, lock=None, attempts=2,
+                           delay=0.2, sleep=None, name=""):
+    """Write a characteristic, retrying a transient failure once.
+
+    Commands only. A poll payload is already stale by the time its write fails
+    and the next poll asks the same question a moment later, so `ble._hold`
+    deliberately does not use this. A command is a user action that nothing
+    else repeats -- if the switch write is dropped, the switch simply does not
+    move -- so it is worth one more attempt.
+
+    Returns True if the write was accepted.
+    """
+    sleep = sleep or asyncio.sleep
+    for attempt in range(1, attempts + 1):
+        try:
+            if lock is not None:
+                async with lock:
+                    await client.write_gatt_char(char_uuid, value)
+            else:
+                await client.write_gatt_char(char_uuid, value)
+            return True
+        except Exception as e:
+            if attempt < attempts:
+                logging.debug("[%s] write failed (%r); retrying", name, e)
+                await sleep(delay)
+                continue
+            logging.warning("[%s] write failed after %d attempts: %r", name, attempts, e)
+    return False

--- a/solardevice.py
+++ b/solardevice.py
@@ -5,6 +5,7 @@ import asyncio
 
 import logging
 
+from connection import write_with_retry
 from supervisor import try_put
 
 
@@ -200,14 +201,9 @@ class SolarDevice:
         lock = getattr(client, "_solar_write_lock", None)
 
         async def _w():
-            try:
-                if lock is not None:
-                    async with lock:
-                        await client.write_gatt_char(char_uuid, value)
-                else:
-                    await client.write_gatt_char(char_uuid, value)
-            except Exception as e:
-                logging.warning("[{}] characteristic write failed: {}".format(self.logger_name, e))
+            # Commands retry once; polls (ble._hold) deliberately do not.
+            await write_with_retry(client, char_uuid, value, lock=lock,
+                                   name=self.logger_name)
         try:
             asyncio.run_coroutine_threadsafe(_w(), loop)
         except Exception as e:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -28,3 +28,96 @@ def test_backoff_applies_jitter_to_spread_retries():
     assert hi == 15 and lo == 5                         # first retry spread over 5..15
     # jitter never drives the delay below zero
     assert connection.backoff_seconds(1, base=1, jitter=100, rand=lambda a, b: a) == 0.0
+
+
+# --- write_with_retry ------------------------------------------------------
+
+import asyncio
+
+from connection import write_with_retry
+
+
+class _WriteClient:
+    """Fails the first `fail_times` writes, then succeeds."""
+
+    def __init__(self, fail_times=0):
+        self.fail_times = fail_times
+        self.attempts = 0
+        self.written = []
+        self.concurrent = 0
+        self.max_concurrent = 0
+
+    async def write_gatt_char(self, char, value):
+        self.attempts += 1
+        self.concurrent += 1
+        self.max_concurrent = max(self.max_concurrent, self.concurrent)
+        await asyncio.sleep(0)
+        self.concurrent -= 1
+        if self.attempts <= self.fail_times:
+            raise RuntimeError("transient")
+        self.written.append((char, bytes(value)))
+
+
+async def _no_sleep(_):
+    return None
+
+
+def test_a_command_write_that_succeeds_is_not_repeated():
+    client = _WriteClient()
+    ok = asyncio.run(write_with_retry(client, "c", b"\x01", sleep=_no_sleep))
+    assert ok is True
+    assert client.attempts == 1
+
+
+def test_a_command_write_is_retried_once():
+    """A user action is not repeated by anything else, so it gets one more go."""
+    client = _WriteClient(fail_times=1)
+    ok = asyncio.run(write_with_retry(client, "c", b"\x01", sleep=_no_sleep))
+    assert ok is True
+    assert client.attempts == 2
+    assert client.written == [("c", b"\x01")]
+
+
+def test_it_gives_up_after_the_retry_without_raising():
+    client = _WriteClient(fail_times=5)
+    ok = asyncio.run(write_with_retry(client, "c", b"\x01", sleep=_no_sleep))
+    assert ok is False
+    assert client.attempts == 2
+    assert client.written == []
+
+
+def test_the_lock_is_held_for_every_attempt():
+    client = _WriteClient(fail_times=1)
+    lock = asyncio.Lock()
+
+    async def run():
+        await asyncio.gather(
+            write_with_retry(client, "c", b"\x01", lock=lock, sleep=_no_sleep),
+            write_with_retry(client, "c", b"\x02", lock=lock, sleep=_no_sleep),
+        )
+
+    asyncio.run(run())
+    assert client.max_concurrent == 1
+
+
+def test_polls_do_not_retry():
+    """ble._hold writes once and drops the payload -- the next poll re-asks."""
+    import ble
+
+    class _Dev:
+        logger_name = "d"
+        need_polling = True
+        device_write_characteristic_polling = "poll"
+
+        def get_poll_data(self):
+            return [1]
+
+    client = _WriteClient(fail_times=1)
+    client.is_connected = True
+
+    async def run():
+        await ble._hold(_Dev(), client, asyncio.Event(), 0.001, asyncio.sleep)
+
+    asyncio.run(run())
+    assert client.attempts == 1          # not retried
+    assert client.written == []


### PR DESCRIPTION
The retry half of the write item in #46, scoped as agreed: commands retry, polls do not.

## Why the asymmetry
A **command** is a user action that nothing else repeats. If the switch write is dropped, the switch simply does not move — there is no later message that says the same thing.

A **poll** write is already stale by the time it fails, and the next poll asks the same question a moment later. Resending it is worse than dropping it.

So `connection.write_with_retry()` does one retry with a short delay, and only `characteristic_write_value` uses it. `ble._hold` is untouched: it still drops the poll and breaks the link so the connection is re-established.

## Note on the lock
The lock is taken *per attempt*, not held across the delay — holding it would block every other writer for the retry interval. A test asserts two concurrent retrying writes still never overlap.

## Nothing to restore
The old callback retry path was dead code — `if error == "In Progress"` compared an exception to a string, so it was always False. This is new behaviour rather than a repair.

## Tests
Five added to `tests/test_connection.py`: a successful write not repeated, a failure retried once and succeeding, a persistent failure giving up after two attempts without raising, the lock held for every attempt, and `ble._hold` still writing exactly once and dropping the payload.

Being honest about these: unlike the previous PRs in this series they do not "fail on master" — the helper does not exist there, so the file fails at collection. The one that characterises existing behaviour is `test_polls_do_not_retry`, which pins the poll path against a future change to this helper leaking into it. Full suite 120 passing.
