### PR TITLE
Delete dead plugin code

### DIFF
--- a/plugins/Hacien/__init__.py
+++ b/plugins/Hacien/__init__.py
@@ -57,16 +57,6 @@ class Util():
                     crc >>= 1
         return crc
 
-    def getValue(self, buf: bytearray, start: int, length: int = 1) -> int:
-        ''' Reads length bytes from buf '''
-        if length == 1:
-            return int(buf[start])
-        if length == 2:
-            return int(buf[start]*256 + buf[start + 1])
-        return 0
-
-
-
     def notificationUpdate(self, data, char):
         logging.debug("broadcastUpdate Start {} {}".format(data, data.hex()))
         if self.PowerDevice.config.getboolean('monitor', 'debug', fallback=False):

--- a/plugins/Meritsun/__init__.py
+++ b/plugins/Meritsun/__init__.py
@@ -66,41 +66,6 @@ class Util():
 
 
 
-    def getValue_old(self, buf, start, end):
-        # Reads "start" -> "end" from "buf" and return the hex-characters in the correct order
-        e = end + 1
-        b = end - 1
-        string = ""
-        while b >= start:
-            chrs = buf[b:e]
-            # logging.debug(chrs)
-            e = b
-            b = b - 2
-            string += chr(chrs[0]) + chr(chrs[1])
-            # logging.debug(string)
-        try:
-            ret = int(string, 16)
-        except Exception as e:
-            ret = 0
-        return ret
-
-
-    def asciitochar(self, a, b):
-        x1 = 0
-        if a >= 48 and a <= 57:
-            x1 = a - 48
-        elif a < 65 or a > 70:
-            x1 = 0
-        else:
-            x1 = (a - 65) + 10
-        x2 = x1 << 4
-        if b >= 48 and b <= 57:
-            return x2 + (b - 48)
-        if b < 65 or b > 70:
-            return x2 + 0
-        return x2 + (b - 65) + 10
-
-
     def validateChecksum(self, buf):
         # logging.debug(f"Checksum-calc: buf: {buf}")
         Chksum1 = 0

--- a/plugins/Topband/__init__.py
+++ b/plugins/Topband/__init__.py
@@ -44,34 +44,16 @@ class Util():
         return ascii_hex_value(buf, start, end)
 
 
-    def asciitochar(self, a, b):
-        x1 = 0
-        if a >= 48 and a <= 57:
-            x1 = a - 48
-        elif a < 65 or a > 70:
-            x1 = 0
-        else:
-            x1 = (a - 65) + 10
-        x2 = x1 << 4
-        if b >= 48 and b <= 57:
-            return x2 + (b - 48)
-        if b < 65 or b > 70:
-            return x2 + 0
-        return x2 + (b - 65) + 10
-
-
     def validateChecksum(self, buf):
         Chksum1 = 0
         Chksum2 = 0
         # end = 114
         j = 1
         while j < self.end - 5:
-            # Chksum1 = int((self.asciitochar(buf[j], buf[j + 1]) + Chksum1))
             Chksum1 = self.getValue(buf, j, j + 1) + Chksum1
             j += 2
         # logging.debug("Checksum 1: {}".format(Chksum1))
 
-        # Chksum2 = ((int(self.asciitochar(buf[j], buf[j + 1]))) << 8) + (int(self.asciitochar(buf[j + 2], buf[j + 3])))
         Chksum2 = (self.getValue(buf, j, j + 1) << 8) + self.getValue(buf, j + 2, j + 3)
 
         # logging.debug("Checksum 2: {}".format(Chksum2))


### PR DESCRIPTION
Phase 0 of the shared-bases work in #46: delete rather than hoist.

Nothing calls any of these — not the plugins, not `solardevice`, not `ble`:

| | lines | note |
|---|---|---|
| `Meritsun.asciitochar` | 16 | superseded by `getValue` |
| `Meritsun.getValue_old` | 19 | |
| `Topband.asciitochar` | 16 | byte-identical to Meritsun's |
| `Hacien.getValue` | 10 | never had a call site |

`asciitochar` is exactly the kind of thing a line-count-driven refactor hoists into a base — 32 identical lines across two plugins. It should be deleted instead.

Also removes two commented-out lines in `Topband.validateChecksum` which were the only remaining mentions of `asciitochar`. Left in, they send a reader looking for a method that no longer exists.

63 lines gone, no behaviour touched, full suite 120 passing.
