### PR TITLE
Derive charge power for SolarLink

### DIFF
--- a/plugins/SolarLink/__init__.py
+++ b/plugins/SolarLink/__init__.py
@@ -137,6 +137,14 @@ class Util():
         self.PowerDevice.entities.charge_voltage = modbus.bytes_to_int(bs, 5, 2) * 0.1
         logging.debug("mElectricity {} {} => {} A".format(int(bs[7]), int(bs[8]), modbus.bytes_to_int(bs, 7, 2) * 0.01))
         self.PowerDevice.entities.charge_current = modbus.bytes_to_int(bs, 7, 2) * 0.01
+        # The regulator reports charge voltage and current but not their product;
+        # derive it so charge power is available like every other power reading.
+        charge_power_watts = (self.PowerDevice.entities.charge_voltage
+                              * self.PowerDevice.entities.charge_current)
+        logging.debug("mChargePower {} V * {} A => {} W".format(
+            self.PowerDevice.entities.charge_voltage,
+            self.PowerDevice.entities.charge_current, charge_power_watts))
+        self.PowerDevice.entities.charge_power = charge_power_watts
         logging.debug("mDeviceTemperature {}".format(int(bs[9])))
         temp_celsius = modbus.bytes_to_int(bs, 9, 1)
         if temp_celsius > 128:

--- a/tests/test_solarlink_charge_power.py
+++ b/tests/test_solarlink_charge_power.py
@@ -1,0 +1,71 @@
+"""SolarLink derives charge power from the voltage and current it reports.
+
+Originally the `charge-power` branch (2026-07-17), which could not be merged:
+it predates the protocol-module refactor and calls a method that no longer
+exists.
+"""
+
+import pytest
+
+from plugins.SolarLink import Util as SolarLinkPlugin
+
+
+class _Entities:
+    """Records what the plugin assigns, applying the same W -> mW scaling as
+    the real `charge_power` property. Everything else is stored as given."""
+
+    def __init__(self):
+        self.charge_mpower = None
+
+    @property
+    def charge_power(self):
+        return round(self.charge_mpower / 1000, 1)
+
+    @charge_power.setter
+    def charge_power(self, watts):
+        self.charge_mpower = watts * 1000
+
+
+class _Device:
+    def __init__(self):
+        self.entities = _Entities()
+        self.device_id = 1
+
+
+def battery_param_frame(decivolts, centiamps):
+    """A full BatteryParamInfo response.
+
+    header(3), soc(2), charge voltage(2), charge current(2), device temp(1),
+    battery temp(1), load voltage(2), load current(2), load power(2).
+    """
+    return [0x01, 0x03, 0x0E,
+            0x00, 0x64,                              # soc 100
+            decivolts >> 8, decivolts & 0xFF,        # charge voltage, /10 V
+            centiamps >> 8, centiamps & 0xFF,        # charge current, /100 A
+            0x19,                                    # device temperature
+            0x14,                                    # battery temperature
+            0x00, 0x87,                              # load voltage
+            0x00, 0x32,                              # load current
+            0x00, 0x2A]                              # load power
+
+
+@pytest.mark.parametrize(
+    ("decivolts", "centiamps", "expected_watts"),
+    [
+        (135, 250, 13.5 * 2.5),      # 13.5 V at 2.5 A
+        (0, 0, 0),                   # nothing coming in
+        (288, 1000, 28.8 * 10.0),    # a 24 V bank charging hard
+    ],
+)
+def test_charge_power_is_voltage_times_current(decivolts, centiamps, expected_watts):
+    device = _Device()
+    plugin = SolarLinkPlugin(power_device=device)
+    plugin.updateBatteryParamInfo(battery_param_frame(decivolts, centiamps))
+    assert device.entities.charge_power == pytest.approx(round(expected_watts, 1))
+
+
+def test_voltage_and_current_are_still_reported():
+    device = _Device()
+    SolarLinkPlugin(power_device=device).updateBatteryParamInfo(battery_param_frame(135, 250))
+    assert device.entities.charge_voltage == pytest.approx(13.5)
+    assert device.entities.charge_current == pytest.approx(2.5)


### PR DESCRIPTION
The regulator reports charge voltage and charge current but not their product, so charge power was the one power reading missing.

Takes the intent of the **`charge-power` branch** (2026-07-17), which cannot be merged: it is 79 commits behind and calls `self.Bytes2Int`, removed by the protocol-module refactor in #73. The calculation itself is unchanged — `entities.charge_power` already scales W to mW.

```python
charge_power_watts = (self.PowerDevice.entities.charge_voltage
                      * self.PowerDevice.entities.charge_current)
```

The branch can be deleted once this lands.

## Tests
`tests/test_solarlink_charge_power.py`, 4 cases: charge power as the product across three voltage/current pairs, and voltage and current still reported unchanged. Three fail on `master`.

Building the fixture turned up that `updateBatteryParamInfo` reads through `bs[16]` — soc, charge voltage, charge current, device and battery temperature, then load voltage, current and power. The helper builds a full response rather than a truncated one, with each field commented.

Full suite 145 passing.