### PR TITLE
Republish discovery configs hourly, not on every resend

### DIFF
--- a/datalogger.py
+++ b/datalogger.py
@@ -9,6 +9,13 @@ import socket
 
 
 
+# How often a retained discovery config is rewritten to the broker. It has to
+# happen occasionally -- a broker that lost its retained store would otherwise
+# never get the configs back -- but it does not have to happen on every timed
+# resend, which republished every entity's config every few minutes.
+DISCOVERY_REPUBLISH_SECONDS = 3600
+
+
 class DataLoggerMqtt():
     def __init__(self, broker, port, prefix=None, username=None, password=None, hostname=None, device_types=None):
         logging.debug("Creating new MQTT-logger")
@@ -54,10 +61,10 @@ class DataLoggerMqtt():
         self.client.connect(broker, port)                                   # establish connection
         self.client.loop_start()                                            # start the loop
 
-        # A set, not a list: `publish(refresh=True)` re-appends an already-known
-        # topic, so this grew without bound -- 1000 entries for one unique topic
-        # on a long-running install -- and every publish paid a linear scan.
-        self.sensors = set()
+        # topic -> when its retained discovery config was last published.
+        # (A dict rather than the original list, which `publish(refresh=True)`
+        # re-appended to without bound -- 1000 entries for one unique topic.)
+        self.sensors = {}
         self.sets = {}
         if not prefix.endswith("/"):
             prefix = prefix + "/"
@@ -77,7 +84,10 @@ class DataLoggerMqtt():
 
     def publish(self, device, var, val, refresh=False):
         topic = "{}{}/{}/state".format(self.prefix, device, var)
-        if topic not in self.sensors or refresh:
+        published_at = self.sensors.get(topic)
+        due_for_republish = (published_at is not None and refresh
+                             and time.monotonic() - published_at >= DISCOVERY_REPUBLISH_SECONDS)
+        if published_at is None or due_for_republish:
             if "power_switch" in var:
                 self.create_switch(device, var)
                 self.create_listener(device, var)
@@ -90,7 +100,7 @@ class DataLoggerMqtt():
                 # entities went missing after a container restart, which resets
                 # self.sensors and so re-ran this block for every entity.
                 self.create_sensor(device, var)
-            self.sensors.add(topic)
+            self.sensors[topic] = time.monotonic()
         logging.debug("Publishing to MQTT {}: {} = {}".format(self.broker, topic, val))
         # Switch state at QoS 1 so a toggle during a disconnect is delivered on
         # reconnect rather than silently dropped; high-frequency sensor state

--- a/tests/test_discovery_republish.py
+++ b/tests/test_discovery_republish.py
@@ -1,0 +1,77 @@
+"""Retained discovery configs are republished occasionally, not constantly.
+
+`log()` passes `refresh=True` on its timed resend, and `publish()` treated that
+as "rewrite this entity's discovery config" — so every entity's config went to
+the broker every few minutes. The surviving intent of the `NewBattery` branch
+(2024-03-25); its other half, a longer resend interval, became #67.
+"""
+
+import configparser
+from datetime import datetime, timedelta
+
+import pytest
+
+import datalogger
+from datalogger import DataLogger
+
+
+def make_logger(refresh_minutes=10):
+    config = configparser.ConfigParser()
+    config["mqtt"] = {"broker": "mqtt.example.net", "hostname": "test-host"}
+    config["datalogger"] = {"refresh": str(refresh_minutes)}
+    return DataLogger(config)
+
+
+def config_publishes(logger, var="voltage"):
+    return [topic for topic, *_ in logger.mqtt.client.published
+            if topic.startswith("homeassistant/") and topic.endswith(f"/{var}/config")]
+
+
+def force_resend_due(logger, device="battery_1", var="voltage"):
+    """Age the stored timestamp so log() takes its timed-resend branch."""
+    logger.logdata[device][var]["ts"] = datetime.now() - timedelta(minutes=99)
+
+
+def test_a_new_entity_publishes_its_config_once():
+    logger = make_logger()
+    logger.log("battery_1", "voltage", 13.7)
+    assert len(config_publishes(logger)) == 1
+
+
+def test_a_timed_resend_does_not_republish_the_config():
+    logger = make_logger()
+    logger.log("battery_1", "voltage", 13.7)
+    for _ in range(5):
+        force_resend_due(logger)
+        logger.log("battery_1", "voltage", 13.7)
+    assert len(config_publishes(logger)) == 1
+
+
+def test_the_config_is_republished_once_the_interval_has_passed(monkeypatch):
+    """A broker that lost its retained store still gets the configs back."""
+    clock = [0.0]
+    monkeypatch.setattr(datalogger.time, "monotonic", lambda: clock[0])
+
+    logger = make_logger()
+    logger.log("battery_1", "voltage", 13.7)          # config published at t=0
+
+    clock[0] = datalogger.DISCOVERY_REPUBLISH_SECONDS - 1
+    force_resend_due(logger)
+    logger.log("battery_1", "voltage", 13.7)          # still inside the interval
+    assert len(config_publishes(logger)) == 1
+
+    clock[0] = datalogger.DISCOVERY_REPUBLISH_SECONDS + 1
+    force_resend_due(logger)
+    logger.log("battery_1", "voltage", 13.7)
+    assert len(config_publishes(logger)) == 2
+
+
+def test_the_state_is_still_sent_on_every_resend():
+    """Throttling the config must not throttle the reading itself."""
+    logger = make_logger()
+    logger.log("battery_1", "voltage", 13.7)
+    for _ in range(5):
+        force_resend_due(logger)
+        logger.log("battery_1", "voltage", 13.7)
+    states = [t for t, *_ in logger.mqtt.client.published if t.endswith("/voltage/state")]
+    assert len(states) == 6


### PR DESCRIPTION
The surviving half of the `NewBattery` branch (2024-03-25), and the last open item on #46.

## What was happening
`log()` passes `refresh=True` on its timed resend, and `publish()` treated that as "rewrite this entity's retained discovery config":

```python
if topic not in self.sensors or refresh:
    self.create_sensor(device, var)      # a retained config publish
```

So every entity's discovery config went to the broker every `refresh` minutes — by default every 10, for every entity on every device.

## Why throttle rather than remove
The `NewBattery` branch simply dropped the `True`. That is most of the way right, but not quite: a broker that lost its retained store would then never get the configs back, and the entities would vanish from Home Assistant until a restart of the monitor.

So the republish is kept and rate-limited to `DISCOVERY_REPUBLISH_SECONDS` (1 hour). Recovery still happens; the traffic drops by a factor of six at the default interval.

`self.sensors` becomes `topic -> when that config was last published`. It stays a mapping keyed by topic, so `in` and `len()` behave as before and #64's tests are untouched.

## Note on the other half
The branch also changed the resend interval from 1 to 15 minutes. That became a config option in #67 (`refresh`, default 10), so it is not carried over. **`NewBattery` can be deleted** once this lands.

## Tests
`tests/test_discovery_republish.py`, 4 cases: a new entity publishes its config once, five timed resends do not republish it, it *is* republished once the hour has passed, and the state reading is still sent on every resend — throttling the config must not throttle the data. The clock is controlled from the start, since the stored timestamp and the comparison have to share one.

Full suite 145 passing.