### PR TITLE
Connection model is always-persistent; drop options nothing reads

### DIFF
--- a/docs/BLUETOOTH.md
+++ b/docs/BLUETOOTH.md
@@ -66,17 +66,24 @@ its connect→resolve window at a time, held just for that window, then released
 while already-resolved links stay held. Several devices can be *connected* at
 once; only the act of *connecting* is serialized.
 
-## Connection model (persistent vs rotating)
+## Connection model
 
-- **Persistent (recommended for all devices):** each device is held connected
-  continuously (`persistent = True` in its ini section). A healthy adapter holds
-  them all. Required for **pure-notify** devices (e.g. Meritsun batteries) that
-  never answer polls — they only push notifications, so they must stay connected
-  to deliver any data at all.
-- **Rotating (fallback):** if a controller genuinely cannot hold that many links,
-  leave devices non-persistent and they share one slot — connect, read for
-  `rotate_dwell` seconds, disconnect, next (`rotate_gap` between). Poor fit for
-  pure-notify devices, which may not push data within a short dwell.
+Every configured device is held connected continuously. A healthy adapter holds
+them all: the reference install keeps four links (two batteries, a regulator and
+an inverter) for weeks at a time without a single reconnect.
+
+This is not merely preferred, it is required for **pure-notify** devices such as
+the Meritsun batteries. They never answer polls — they only push notifications —
+so they deliver no data at all unless they stay connected.
+
+Earlier versions offered a rotating model, where devices shared one connection
+slot in turn. It was a workaround for controllers that could not hold several
+links, and it was removed with the move to bleak. The two failures that motivated
+it were fixed at their root instead: concurrent connection establishment, now
+serialised behind a single lock so only one LE Create Connection is ever in
+flight, and 2.4 GHz coexistence, addressed host-side (see below). If you meet an
+adapter that genuinely cannot hold your devices, that is worth reporting — the
+fix belongs in the connection layer rather than in a per-device option.
 
 ## Optional host connection-parameter tuning
 

--- a/solar-monitor.ini.dist
+++ b/solar-monitor.ini.dist
@@ -2,24 +2,19 @@
 adapter = hci0
 debug = False
 temperature = C
-reconnect = False
 # C = Celsius
 # K = Kelvin
 # F = Farenheit
 #
-# BLE connection model. Normally EVERY device should be held connected
-# continuously (`persistent = True` in each device's section below) — a healthy
-# adapter easily holds all of them, and pure-notify devices (which never answer
-# polls, they only push notifications) MUST stay connected to deliver any data.
+# Every configured device is held connected continuously; there is nothing to
+# configure. Pure-notify devices (which never answer polls, they only push
+# notifications) require it, and a healthy adapter holds them all. See
+# docs/BLUETOOTH.md if an adapter struggles.
 #
-# If your controller genuinely cannot hold that many links at once, mark only
-# the must-have-real-time devices persistent and leave the rest as "rotating":
-# rotating devices share ONE connection slot — connect, read for `rotate_dwell`
-# seconds, disconnect, move to the next. Note rotation is a poor fit for
-# pure-notify devices, which may not push data within a short dwell.
-#
-#   rotate_dwell = 30    # seconds to hold each rotating device while reading
-#   rotate_gap = 5       # seconds to wait between rotating devices
+# Per device, optional:
+#   trusted = True   # mark the device Trusted in BlueZ so it is not discarded
+#                    # as "temporary" and BlueZ reconnects it itself. Defaults
+#                    # to on for devices that need polling.
 #
 # IMPORTANT (Raspberry Pi and other WiFi/BT combo chips): a 2.4 GHz WiFi AP on
 # the same chip starves Bluetooth and makes connections fail with
@@ -30,19 +25,14 @@ reconnect = False
 [renogy_battery_1]
 type = RenogyBatt
 mac = 11:11:11:11:11:11
-reconnect = True
 
 [battery_1]
 type = Meritsun
 mac = 11:11:11:11:11:11
-reconnect = False
-persistent = True
 
 [battery_2]
 type = Meritsun
 mac = 11:11:11:11:11:11
-reconnect = False
-persistent = True
 
 [regulator]
 type = SolarLink
@@ -51,20 +41,15 @@ mac = 11:11:11:11:11:11
 # hardware -- see "Tuning the value limits" in the README. Units are milli-
 # whatever, so this is a 96 V panel input:
 # input_mvoltage_max = 96000
-reconnect = False
 # Hold every device connected continuously (recommended). See [monitor] above.
-persistent = True
 
 [inverter_1]
 type = VEDirect
 mac = 11:11:11:11:11:11
-reconnect = False
-persistent = True
 
 [rectifier_1]
 type = VEDirect
 mac = 11:11:11:11:11:11
-reconnect = False
 
 
 [datalogger]

--- a/tests/test_shipped_config.py
+++ b/tests/test_shipped_config.py
@@ -36,3 +36,30 @@ def test_no_credential_looking_token():
     assert token in ("", "your-token-here"), (
         f"shipped token should be a placeholder, got {token!r}"
     )
+
+
+def test_every_shipped_option_is_read_by_the_code():
+    """An option in the .dist that nothing reads is a promise the code breaks.
+
+    `persistent` was documented and offered for a year after the rotating
+    connection model it selected had been deleted, and `reconnect` was shipped
+    in seven places while no code ever read it (#76).
+    """
+    import glob
+    import re
+
+    root = os.path.dirname(DIST)
+    sources = "\n".join(
+        open(f, encoding="utf-8").read()
+        for f in glob.glob(os.path.join(root, "*.py"))
+        + glob.glob(os.path.join(root, "plugins", "*", "__init__.py"))
+    )
+
+    cp = _read_dist()
+    unread = []
+    for section in cp.sections():
+        for option in cp.options(section):
+            if not re.search(rf"""['"]{re.escape(option)}['"]""", sources):
+                unread.append(f"[{section}] {option}")
+    assert not unread, (
+        "shipped in solar-monitor.ini.dist but read by no code: " + ", ".join(unread))


### PR DESCRIPTION
Fixes #76.

## The mismatch
`docs/BLUETOOTH.md` and `solar-monitor.ini.dist` described a **persistent vs rotating** connection model and offered `persistent` per device. No code has read it since the bleak migration deleted `rotate_devices` — so anyone setting `persistent = False` got persistent behaviour, silently.

## Rotation is not reimplemented, deliberately
It was a *fallback* for controllers that could not hold several links, and the two failures behind it were fixed at their root instead — concurrent connection establishment, now serialised behind `connect_lock`, and 2.4 GHz coexistence, addressed host-side.

The evidence that it is no longer needed is the reference install: four day-logs of 23–26k lines each, covering 14–17 August, contain **no connection event of any kind** — no connect, reconnect, disconnect or link loss. The container had been running since 20 July. Four LE links held for roughly four weeks without a single drop.

It is also a poor fit for pure-notify devices, per the docs' own warning, and those are half the devices on that install (soon three of five).

If an adapter ever genuinely cannot hold its devices, that is worth a report and a fix in the connection layer, not a per-device option that breaks notify devices.

## Also in this change
Auditing the rest of the file turned up two more of the same defect:

- **`reconnect`** — shipped in **seven** places, read by no code at all. Removed.
- **`trusted`** — the inverse: read at `monitor_app.py:146`, defaulting to on for polled devices, and documented nowhere. Now documented.

## The durable part
`tests/test_shipped_config.py` gains a check that every option the `.dist` ships is referenced somewhere in the code. Against the previous file it names all eleven stale entries:

```
[monitor] reconnect, [battery_1] reconnect, [battery_1] persistent, ...
```

That is what would have caught this a year ago, and what will catch the next one.

Full suite 150 passing.
