### PR TITLE
Self-contained image: multi-stage, without the dead toolchain

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Only what runs belongs in the image.
+
+.git
+.gitignore
+.github
+
+# The config is mounted at runtime. solar-monitor.ini.dist is not matched here
+# and ships as the example.
+*.ini
+
+# Reverse-engineering captures.
+plugins/*/dev/
+
+tests/
+docs/
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+*.log
+core.*
+docker-compose*.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,29 @@
-FROM python:3.11-slim-bullseye
+# libscrc publishes no wheels, so it is compiled here and the toolchain stays
+# out of the runtime image.
+FROM python:3.11-slim-bookworm AS builder
 
-RUN apt update && apt -y install --no-install-recommends bluetooth build-essential cmake autoconf automake pkg-config libdbus-1-dev libglib2.0-dev libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
+
+
+FROM python:3.11-slim-bookworm
+
+# bluez provides bluetoothctl, which ble.set_trusted shells out to. bleak
+# reaches D-Bus through pure-python dbus-fast and needs nothing else.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bluez \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /wheels /wheels
+COPY requirements.txt .
+RUN pip install --no-cache-dir --no-index --find-links=/wheels -r requirements.txt \
+    && rm -rf /wheels requirements.txt
 
 WORKDIR /solar-monitor
 COPY . .
 
-RUN pip install -r requirements.txt
-
 ENTRYPOINT [ "python", "-u", "solar-monitor.py" ]
-


### PR DESCRIPTION
First two items of #47. The image carried 12 MB it never used, and a build toolchain for dependencies that no longer exist.

## `.dockerignore` (new)
`COPY . .` was sending the git history (2.6 MB) and `plugins/*/dev` (**9.2 MB** of pcapng captures) into the image, and would bake a local `solar-monitor.ini` — MQTT password and datalogger token — into a readable layer. Build context drops to **708 K**.

`solar-monitor.ini.dist` still ships as the example; `*.ini` does not match it.

## Dockerfile
The old image installed `build-essential cmake autoconf automake pkg-config libdbus-1-dev libglib2.0-dev libgirepository1.0-dev libcairo2-dev gir1.2-gtk-3.0`. **All of it was for PyGObject/dbus-python**, which bleak replaced — bleak reaches D-Bus through pure-python `dbus-fast`, and nothing imports `gi` or `dbus` any more:

```
$ git grep -E "^\s*(import|from)\s+(gi|dbus|gatt)\b" -- '*.py' | grep -v tests/
(nothing)
```

The one genuine compile left is `libscrc`, which publishes **no wheels** — source tarball only. So it is built in a stage that never ships, and the runtime image keeps only `bluez`, for the `bluetoothctl` that `ble.set_trusted` shells out to. Base moves bullseye → bookworm.

**581 MB → 190 MB.**

Verified on the built image: every dependency imports, `bluetoothctl` is at `/usr/bin/bluetoothctl`, running with no config gives a clean `Unable to read ini-file`, and running with the shipped example loads the whole stack and gets as far as resolving the broker.

This should also take a large bite out of the multi-hour Pi Zero rebuild #47 mentions — most of what it was compiling is simply gone.

## Not in this change
Non-root (`USER`), dependency pinning, and the docs items. Non-root in particular needs the D-Bus policy check #47 already calls for, so it deserves its own change.
