### PR TITLE
Comments state what the code does, not what it did

### DIFF
--- a/asciihex.py
+++ b/asciihex.py
@@ -1,9 +1,8 @@
 """ASCII-hex framing, shared by the plugins that speak it.
 
-Meritsun and Topband encode every byte as two ASCII hex characters, least
-significant pair first, and protect a frame with a 16-bit additive checksum --
-not the CRC the Modbus devices use. Their frame layouts and packet types differ
-and stay in the plugins.
+Every byte is two ASCII hex characters, least significant pair first, and a
+frame is protected by a 16-bit additive checksum. Frame layouts and packet types
+differ per device and belong in the plugin.
 """
 
 import logging

--- a/ble.py
+++ b/ble.py
@@ -188,14 +188,13 @@ class BleManager:
 
 def command_bridge(datalogger, devices_by_name, manager, stop_event):
     """Threaded: consume MQTT commands (datalogger.mqtt.sets/trigger) and route
-    them to the async layer. Replaces the per-device mqtt_poller thread.
+    them to the async layer.
 
     The datalogger's on_message drains into mqtt.sets[device] and fires
-    mqtt.trigger[device] -- but nothing else creates those trigger Events (the
-    slim SolarDevice no longer does), so we register a single shared wake Event
-    for every device here. We also drain on the 0.5s poll timeout, so a command
-    that arrives before its trigger is registered (or with no trigger at all) is
-    still delivered."""
+    mqtt.trigger[device]. Nothing else creates those trigger Events, so one
+    shared wake Event is registered for every device here. Draining also happens
+    on the 0.5s poll timeout, so a command that arrives before its trigger is
+    registered -- or with no trigger at all -- is still delivered."""
     if not (datalogger and datalogger.mqtt):
         return
     mqtt = datalogger.mqtt

--- a/codec.py
+++ b/codec.py
@@ -7,11 +7,7 @@ Separate from `solardevice` so plugins can import it without a cycle:
 import logging
 
 # Two's-complement wrap points. A reading above the signed maximum is negative
-# and wraps by 2**bits. Every plugin open-coded this with its own constant and
-# each was short of 2**bits: Meritsun and Topband by one LSB (2**32 - 1),
-# RenogyBatt by two (65534, not 65536, for both current and temperature). So
-# every negative reading came out high -- by +0.02 A on RenogyBatt current,
-# which integrates into roughly 1.7 Ah/day of phantom charge.
+# and wraps by 2**bits.
 UINT16_WRAP = 1 << 16      # 65536
 UINT32_WRAP = 1 << 32      # 4294967296
 INT16_MAX = (1 << 15) - 1  # 32767

--- a/connection.py
+++ b/connection.py
@@ -5,10 +5,7 @@ but often aborts during GATT service resolution; it is transient and succeeds on
 retry. Exponential backoff (with jitter, so retries across devices don't all
 land at once) is the shared policy used for retrying failed connects.
 
-The thread-based connection loops that used to live here (`maintain_device`,
-`rotate_devices`, built on the abandoned `gatt` library) were replaced by the
-asyncio `maintain_device` in `ble.py` (bleak-based), which imports
-`backoff_seconds` from this module.
+`ble.py`'s asyncio `maintain_device` imports `backoff_seconds` from here.
 """
 import asyncio
 import logging

--- a/datalogger.py
+++ b/datalogger.py
@@ -61,9 +61,7 @@ class DataLoggerMqtt():
         self.client.connect(broker, port)                                   # establish connection
         self.client.loop_start()                                            # start the loop
 
-        # topic -> when its retained discovery config was last published.
-        # (A dict rather than the original list, which `publish(refresh=True)`
-        # re-appended to without bound -- 1000 entries for one unique topic.)
+        # topic -> when its retained discovery config was last published
         self.sensors = {}
         self.sets = {}
         if not prefix.endswith("/"):
@@ -323,8 +321,7 @@ class DataLogger():
         self.refresh_interval = config.getint('datalogger', 'refresh', fallback=10)
         if config.get('datalogger', 'url', fallback=None):
             self.url = config.get('datalogger', 'url')
-            # Optional: an ingest endpoint may not require auth, and a missing
-            # token used to raise NoOptionError at startup.
+            # Optional: an ingest endpoint may not require auth.
             self.token = config.get('datalogger', 'token', fallback=None)
         if config.get('mqtt', 'broker', fallback=None):
             device_types = {}
@@ -378,11 +375,8 @@ class DataLogger():
             self.logdata[device][var]['ts'] = ts
             self.logdata[device][var]['value'] = None
 
-        # Remember a value as sent only once it has been. Committing first meant
-        # a publish that failed -- a broker outage, a dropped link -- left the
-        # cache claiming the value was delivered, so the next identical reading
-        # compared equal and never resent it. The change then waited for the
-        # value to move again or for the 10-minute refresh.
+        # Remember a value as sent only once it has been: an undelivered value
+        # must stay different from the cache so the next reading resends it.
         if self.logdata[device][var]['value'] != val:
             logging.info("[{}] Sending new data {}: {}".format(device, var, val))
             if self.send_to_server(device, var, val):

--- a/modbus.py
+++ b/modbus.py
@@ -1,8 +1,7 @@
 """Modbus RTU framing, shared by the plugins that speak it.
 
-RenogyBatt and SolarLink had byte-identical copies of all of this. The parts
-that genuinely differ between those devices -- which registers to poll, how to
-build a request, how to interpret a response -- stay in the plugins.
+What differs per device -- which registers to poll, how to build a request, how
+to interpret a response -- belongs in the plugin.
 """
 
 import logging

--- a/plugins/Meritsun/__init__.py
+++ b/plugins/Meritsun/__init__.py
@@ -71,16 +71,11 @@ class Util():
             return False
 
         # The device streams frames back-to-back behind two markers, 0x92 and
-        # 0xC9. Both carry the same layout -- every checksum-valid frame decodes
-        # identically regardless of marker, and 0xC9 carries about two thirds of
-        # them -- so both start a frame.
-        # Neither marker, nor the END_VAL (0x0C) padding, ever appears inside the
-        # ASCII-hex payload, so the markers delimit packets unambiguously. We
-        # accumulate the stream and re-sync on every marker, so a single lost or
-        # reframed notification can no longer desync the parser permanently the
-        # way the old fixed-121-byte logic did (which, after the trixie/BlueZ 5.82
-        # notification-framing change, gave up after the first frame). Unknown,
-        # short or corrupt packets are simply skipped.
+        # 0xC9, both carrying the same layout. Neither marker, nor the END_VAL
+        # (0x0C) padding, appears inside the ASCII-hex payload, so they delimit
+        # packets unambiguously. Accumulating and re-syncing on every marker
+        # keeps a lost or reframed notification from desyncing the parser.
+        # Unknown, short or corrupt packets are skipped.
         if not hasattr(self, '_stream'):
             self._stream = bytearray()
         self._stream.extend(data)
@@ -117,9 +112,8 @@ class Util():
         return updated
 
     def _frameEnd(self, packet):
-        # The checksum spans the frame up to its trailing 0x0C padding. `find`
-        # stops at the first 0x0C, which in this stream sits far too early; the
-        # device's own rule is the last padding byte before offset 110.
+        # The checksum spans the frame up to its trailing 0x0C padding: the last
+        # padding byte before offset 110, not the first 0x0C in the packet.
         end = 0
         for i in range(1, min(len(packet), 122)):
             if packet[i] == self.END_VAL and end < 110:
@@ -127,9 +121,8 @@ class Util():
         return end
 
     def _handleDataPacket(self, packet):
-        # Gate on the protocol checksum -- the only invariant that holds. The
-        # previous signature gate keyed on bytes that turned out to be live data:
-        # it matched 142/363 frames in July and 0/122 in August.
+        # The protocol checksum is the only invariant that holds across pack
+        # states; field values that look constant are not.
         buf = [0] * 122
         for k in range(min(len(packet), 122)):
             buf[k] = packet[k]

--- a/solardevice.py
+++ b/solardevice.py
@@ -119,9 +119,7 @@ class SolarDevice:
 
     def run_command(self, var, message):
         # Only two of the six plugins implement cmdRequest; the rest are
-        # read-only devices. Treat "no commands" as empty rather than letting an
-        # AttributeError reach the caller, where it surfaces as a logged
-        # traceback and a command that silently does nothing.
+        # read-only devices, for which a command is a no-op worth logging.
         cmd_request = getattr(self.util, "cmdRequest", None)
         if cmd_request is None:
             logging.warning("[{}] plugin '{}' accepts no commands; ignoring {} = {}".format(
@@ -190,10 +188,8 @@ class SolarDevice:
         client = self._client
         if client is None or char_uuid is None:
             return
-        # Plugins build write payloads as a bytearray (VEDirect) OR a plain list of
-        # ints (SolarLink). gatt accepted a list; bleak's write_gatt_char needs a
-        # bytes-like object, so a list raised TypeError and the write silently never
-        # happened -- that was the dead SolarLink power switch. Normalise here.
+        # Plugins build write payloads as a bytearray (VEDirect) or a plain list
+        # of ints (SolarLink); write_gatt_char takes only bytes-like.
         if not isinstance(value, (bytes, bytearray, memoryview)):
             value = bytearray(value)
         loop = getattr(client, "_solar_loop", None) or asyncio.get_event_loop()


### PR DESCRIPTION
Comments across these files narrated the bugs they fixed — what the previous version did, what was replaced, what no longer happens. That belongs in the commit history, which already has it, and it ages badly in a live file: the replaced thing recedes every year while the comment keeps insisting on it.

Each is rewritten to the constraint that still applies. For example:

```diff
-# Two's-complement wrap points. A reading above the signed maximum is negative
-# and wraps by 2**bits. Every plugin open-coded this with its own constant and
-# each was short of 2**bits: Meritsun and Topband by one LSB (2**32 - 1),
-# RenogyBatt by two (65534, not 65536, for both current and temperature). So
-# every negative reading came out high -- by +0.02 A on RenogyBatt current,
-# which integrates into roughly 1.7 Ah/day of phantom charge.
+# Two's-complement wrap points. A reading above the signed maximum is negative
+# and wraps by 2**bits.
```

```diff
-        # Remember a value as sent only once it has been. Committing first meant
-        # a publish that failed -- a broker outage, a dropped link -- left the
-        # cache claiming the value was delivered, so the next identical reading
-        # compared equal and never resent it. The change then waited for the
-        # value to move again or for the 10-minute refresh.
+        # Remember a value as sent only once it has been: an undelivered value
+        # must stay different from the cache so the next reading resends it.
```

Kept throughout: the invariant the code is obeying. Dropped: the measurement, the before/after, and the name of the thing that used to be there.

Comments only — 27 lines net removed, no code changed, suite unchanged at 150 passing.