### PR TITLE
Run as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,15 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --no-index --find-links=/wheels -r requirements.txt \
     && rm -rf /wheels requirements.txt
 
+# Match the uid that owns the mounted config and log directories on the host.
+ARG UID=1000
+ARG GID=1000
+RUN groupadd --gid "$GID" solar \
+    && useradd --uid "$UID" --gid "$GID" --no-create-home --shell /usr/sbin/nologin solar \
+    && install -d -o "$UID" -g "$GID" /solar-monitor/solar-monitor
+
 WORKDIR /solar-monitor
-COPY . .
+COPY --chown=$UID:$GID . .
+USER solar
 
 ENTRYPOINT [ "python", "-u", "solar-monitor.py" ]


### PR DESCRIPTION
Next item of #47: the container no longer runs as root.

## The exposure
It ran as uid 0 with config, logs and `/var/run/dbus` mounted in. Anything able to write the mounted directories could execute as root inside the container, with the system bus attached.

## The change
A `UID`/`GID` build arg (default 1000) creates the runtime user, and `USER solar` drops to it.

One subtlety worth flagging for review: `install -d` gives that user the workdir **and** the log directory. `WORKDIR` creates `/solar-monitor` as root before `COPY --chown` runs, so without this `duallog.setup()` cannot create its log directory and startup dies with `PermissionError: 'solar-monitor'`. I hit exactly that on the first build.

## Non-root is enough for BlueZ, and the issue's premise was pessimistic
#47 says to run "as a dedicated user in the `bluetooth` group". On Debian/Raspbian that group is not what grants access — the D-Bus policy shipped with bluez has:

```xml
<policy context="default">
  <allow send_destination="org.bluez"/>
</policy>
```

So any user may call BlueZ. The `send_interface` rules under `policy user="root"` are for *implementing* callback interfaces (`Agent1`, `GattCharacteristic1`), which a pure client does not do.

Verified on the reference host as **`nobody`** — not root, not in the `bluetooth` group:

```
$ sudo -u nobody bluetoothctl show        -> Controller DC:A6:32:05:65:41 ...
$ sudo -u nobody bluetoothctl devices     -> lists all five
$ sudo -u nobody bluetoothctl trust <mac> -> Changing ... trust succeeded
```

That last one is the write `ble.set_trusted` performs, so the one operation that might have needed privilege does not. (State restored afterwards.)

Hosts with a stricter policy exist, which is why the uid is a build arg rather than hardcoded.

## Verified on the built image
`id` reports uid 1000, `/root` is not writable, and all three startup paths behave as before — no config, config without a mounted log dir, and config with one.
