### PR TITLE
Hardened systemd unit, running as a dedicated user

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,31 @@ Also
 * solar-monitor.service - A systemd service-description for auto-starting the service
 * solar-monitor.ini.dist  Configuration-file. To be modified and renamed to solar-monitor.ini
 
-Copy solar-monitor.ini.dist to solar-monitor.ini, and add the correct mac addresses to your BLE devices (NOT your mobile phone with the app, but the actual battery/bluetooth adapter)
+Install the code somewhere the service user cannot write, keep the config
+separate, and run as a dedicated user:
 
-Copy solar-monitor.service to /etc/systemd/system/ and run
+```sh
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin solar-monitor
+
+sudo install -d -o root -g root /opt/solar-monitor
+sudo cp -r *.py plugins /opt/solar-monitor/
+
+sudo install -d -o root -g solar-monitor -m 750 /etc/solar-monitor
+sudo install -o root -g solar-monitor -m 640 solar-monitor.ini /etc/solar-monitor/
 ```
-systemctl daemon-reload
-systemctl enable solar-monitor
-systemctl start solar-monitor
+
+The ini holds your MQTT password and datalogger token, so it is readable by the
+service and nobody else. The shipped unit expects exactly these paths.
+
+```sh
+sudo cp solar-monitor.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now solar-monitor
 ```
-The systemd unit file might need some adjustments to point to the right scripts
+
+BlueZ is reached over the system D-Bus, which the policy shipped with bluez
+allows for any user, so the service needs no capabilities and no group
+membership.
 
 Alternatively just run `solar-monitor.py` in something like termux or screen (might require root privileges to access bluetooth directly)
 

--- a/solar-monitor.service
+++ b/solar-monitor.service
@@ -2,15 +2,29 @@
 Description=Solar Monitor
 After=network.target bluetooth.service
 Wants=bluetooth.service
- 
+
 [Service]
 Type=simple
-User=root
-WorkingDirectory=/home/pi/solar-monitor
-ExecStart=/home/pi/solar-monitor/solar-monitor.py
-RestartSec=13
+User=solar-monitor
+Group=solar-monitor
+
+# Code read-only under /opt, config read-only under /etc, and the one writable
+# path is the state directory systemd creates and owns.
+ExecStart=/usr/bin/python3 -u /opt/solar-monitor/solar-monitor.py --ini /etc/solar-monitor/solar-monitor.ini
+WorkingDirectory=/var/lib/solar-monitor
+StateDirectory=solar-monitor
+
 Restart=always
- 
+RestartSec=13
+
+# BlueZ is reached over the system D-Bus, so no capabilities are needed.
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
The security item of #47, for the systemd deployment. (#80 did the container.)

## The exposure
The shipped unit:

```ini
User=root
WorkingDirectory=/home/pi/solar-monitor
ExecStart=/home/pi/solar-monitor/solar-monitor.py
Restart=always
```

Root executing code under a user-writable path — and `Restart=always` means crashing the service is enough to trigger the next execution.

## The unit now
Runs as `solar-monitor`, with the code read-only under `/opt`, the config read-only under `/etc`, and exactly one writable path: the `StateDirectory` systemd creates and owns. `--ini` points at the config, so nothing depends on the working directory.

```ini
NoNewPrivileges=yes
ProtectSystem=strict
ProtectHome=yes
PrivateTmp=yes
PrivateDevices=yes
RestrictSUIDSGID=yes
LockPersonality=yes
```

**No capabilities and no group membership** — BlueZ is reached over the system D-Bus, which the bluez-shipped policy allows for any user (measured in #80).

## Verified on a real host, not just `systemd-analyze`
`systemd-run` as `nobody` under the full property set:

```
$ ... /usr/bin/bluetoothctl show
Controller DC:A6:32:05:65:41 (public) ...          reaches BlueZ

$ ... sh -c "mkdir -p solar-monitor && echo ok > solar-monitor/test.log; touch /opt/x; touch /etc/x"
ok                                                  StateDirectory writable
touch: '/opt/x': Read-only file system              
touch: '/etc/x': Read-only file system              
```

## README
The service section gains install steps matching those paths, including mode `640` on the ini — it holds the MQTT password and the datalogger token.

## Not verified
The unit has not been run end to end on a host, because the reference install runs the container and a second instance would fight it for the same BLE devices. What is verified is every sandbox property against the real D-Bus and filesystem.