### PR TITLE
Document the MQTT options, the licence and the plugin guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,18 @@ This allows you to remotely monitor the data from your installation:
 
 
 
+# Plugins
+
+Each supported device family has a plugin under `plugins/`, responsible for that
+device's framing and decoding. [PLUGINS.md](PLUGINS.md) describes what a plugin
+must provide and how to add one.
+
+
+# Licence
+
+GPLv3. See [LICENSE](LICENSE).
+
+
 # Credits
 A huge thanks to Pramod P K https://github.com/prapkengr/ for doing reverse engineering and decompiling of the Android Apps to figure out the protocols used.
 

--- a/solar-monitor.ini.dist
+++ b/solar-monitor.ini.dist
@@ -64,9 +64,18 @@ refresh = 10
 
 [mqtt]
 # Address to the mqtt broker
-broker = mqtt.server.addr 
+broker = mqtt.server.addr
+# Port. 1883 plain, 8883 for TLS.
+port = 1883
 # All topics are prefixed by this prefix
 # E.g. "solar/battery_1/voltage"
-prefix = solar                
+prefix = solar
+# Credentials, if the broker requires them. This file then holds a secret:
+# chmod 600 it, or 640 owned by the group the service runs as.
+# username = solar-monitor
+# password = 
+# Client id and Home Assistant device suffix. Defaults to the machine hostname;
+# set it when several machines publish to one broker.
+# hostname = 
 
 

--- a/tests/test_shipped_config.py
+++ b/tests/test_shipped_config.py
@@ -63,3 +63,29 @@ def test_every_shipped_option_is_read_by_the_code():
                 unread.append(f"[{section}] {option}")
     assert not unread, (
         "shipped in solar-monitor.ini.dist but read by no code: " + ", ".join(unread))
+
+
+def test_every_option_the_code_reads_is_documented():
+    """The converse of the test above: an option the code honours but the .dist
+    never mentions is invisible to anyone configuring the tool.
+
+    `username`, `password`, `port` and `hostname` were read by the MQTT logger
+    and appeared nowhere in the shipped example (#47).
+    """
+    import glob
+    import re
+
+    root = os.path.dirname(DIST)
+    sources = "\n".join(
+        open(f, encoding="utf-8").read()
+        for f in glob.glob(os.path.join(root, "*.py"))
+    )
+    # config.get('mqtt', 'port', ...) / config.getboolean(section, 'trusted', ...)
+    read = set(re.findall(
+        r"""config\.get(?:int|boolean|float)?\(\s*(?:section|['"][a-z]+['"])\s*,\s*['"]([a-z_]+)['"]""",
+        sources))
+
+    documented = set(re.findall(r"^#?\s*([a-z_]+)\s*=", open(DIST).read(), re.M))
+    missing = sorted(read - documented)
+    assert not missing, (
+        "read by the code but absent from solar-monitor.ini.dist: " + ", ".join(missing))


### PR DESCRIPTION
The docs item of #47.

## What was missing
The MQTT logger reads four options the shipped example never mentioned:

```
read by the code:   broker debug hostname mac password port prefix refresh token trusted type url username
in the .dist:       adapter broker debug mac prefix refresh temperature token trusted type url
                                    ^^^^^^^^  ^^^^^^^^ ^^^^  ^^^^^^^^
```

So the only way to find `username`, `password`, `port` or `hostname` was to read the source. All four are now in `[mqtt]`, with a note that credentials make the file a secret — `chmod 600`, or `640` owned by the group the service runs as.

## README
- **Plugins** section linking `PLUGINS.md`.
- **Licence** section naming GPLv3 and linking `LICENSE`.

## Already done
This item also asks for the datalogger example to be `https://`. It already is.

## The durable part
`tests/test_shipped_config.py` gains the converse of the check added in #77. That one asserts every option the `.dist` ships is read by the code; this one asserts every option the code reads appears in the `.dist`. Against the previous file it names them precisely:

```
AssertionError: read by the code but absent from solar-monitor.ini.dist: hostname, password, port, username
```

Between the two, a config option cannot drift out of the documentation in either direction.

Suite 151 passing.