### PR TITLE
Group action updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,9 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    groups:
+      # One PR for every action: they all live in the same workflow file, so
+      # separate PRs conflict as soon as the first one merges.
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Every action lives in the same workflow file, so one PR per action conflicts as soon as the first merges. That is exactly what happened with #83 and #84: merging the setup-python bump left the checkout bump `CONFLICTING`, needing a rebase.

```yaml
  - package-ecosystem: github-actions
    groups:
      actions:
        patterns:
          - "*"
```

The pip ecosystem keeps its narrower `bleak` group — those packages genuinely move together, while the rest are independent and are better reviewed apart.