### PR TITLE
Plugin guide: shared helpers, payloads, capture and testing

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -20,7 +20,23 @@ Typically, you can have a hierarchy like
 
 We then *subscribe to* or *write to* one or more of these characteristics.
 
-These UUIDs can be found either by reverse engineering the original app, by sniffing the packets going over the bluetooth connection from the original app, or by using various tools to connect directly to the device with bluetooth and poke around until you find something of interest.  But note that many devices need some kind of "init" before they send any data.  The easiest is probably to run e.g. wireshark to sniff the packets going over the air, and try to figure out what happens.
+Finding these UUIDs, and working out what the bytes mean, is a job of its own:
+[REVERSE-ENGNEER.md](REVERSE-ENGNEER.md) walks through sniffing the vendor app
+with Wireshark. Note that many devices send nothing at all until they receive
+some kind of init.
+
+The shipped plugins are a useful recognition aid. A device advertising one of
+these families probably speaks something close to a protocol already supported:
+
+| Service | Notify characteristic | Used by |
+|---|---|---|
+| `0000ffe0-…` | `0000ffe4-…` | Meritsun, Topband |
+| `0000fff0-…` | `0000fff1-…` | SolarLink (SRNE), RenogyBatt |
+| `306b0001-…` | `306b0002/0003/0004-…` | VEDirect |
+| `6e400001-…` (Nordic UART) | `6e400003-…` | Hacien |
+
+Nordic UART in particular is a generic serial-over-BLE service, so it tells you
+the transport but nothing about the protocol carried over it.
 
 ## Config
 The Config class defines some parameters for the plugin:
@@ -29,7 +45,7 @@ The Config class defines some parameters for the plugin:
 - `SEND_ACK` - Some devices require that an "ack" is returned for all received packets.  If this parameter is set to `True` the `Util` class needs a function `ackData` that generates the ack packets
 - `NEED_POLLING` - Some devices require active polling, while others will just send a continous stream of updates.  If this is set to `True`, the device will be polled every second for updates
 - `NOTIFY_SERVICE_UUID` - The UUID that contains the notifications
-- `NOTIFY_CHAR_UUID` - The characteristics within the `NOTIFY_SERVICE_UUID` that we will subscribe to.  Can be a single UUID or a list of UUIDs
+- `NOTIFY_CHAR_UUID` - The characteristics within the `NOTIFY_SERVICE_UUID` that we will subscribe to.  Can be a single UUID or a list of UUIDs.  Every characteristic in the list is subscribed to: VEDirect spreads its data across three, and subscribing to one of them yields no data and a link the device drops
 - `WRITE_SERVICE_UUID`- The service UUID containing the characteristics we will send write requests to 
 - `WRITE_CHAR_UUID_POLLING` - The charactersitcs UUID we send polling requests, acks etc. to
 - `WRITE_CHAR_UUID_COMMANDS` - The characteristics UUID we send data to for commands.  E.g turing power on or off on a regulator etc.
@@ -58,3 +74,50 @@ Some devices accept commands, such as turning power on and off on an inverter.  
 The function must return a *list* of packets that should be sent to the device.
 
 
+### Payloads
+
+Everything written to the device — from `pollRequest()`, `ackData()` and
+`cmdRequest()` — must be bytes-like: `bytes` or `bytearray`. A plain list of
+ints is coerced on the way out, but returning bytes directly says what you mean.
+
+
+## Decoding helpers
+
+Three modules cover the wire formats the shipped plugins use. A device speaking
+something similar should use them rather than growing its own copy:
+
+- `modbus.py` — `bytes_to_int()`, `high_byte()`, `low_byte()`,
+  `validate_frame()` (length, function code and CRC-16/MODBUS) and
+  `ack_payload()`. Used by `SolarLink` and `RenogyBatt`.
+- `asciihex.py` — `field_value()` for ASCII-hex fields written least significant
+  pair first, and `checksum_matches()` for the 16-bit additive checksum. Used by
+  `Meritsun` and `Topband`.
+- `codec.py` — `to_signed()` and the two's-complement wrap constants, for signed
+  readings in any format.
+
+
+## Capturing what your plugin receives
+
+Wireshark shows what the *vendor app* exchanges. Once your plugin connects, you
+want the bytes your own code receives, which is a different question — framing
+can differ between what the app negotiates and what you get.
+
+The `Meritsun` and `Hacien` plugins write every notification to
+`/tmp/<device-alias>.log` when `debug = True` is set in `[monitor]`:
+
+```python
+if self.PowerDevice.config.getboolean('monitor', 'debug', fallback=False):
+    with open(f"/tmp/{self.PowerDevice.alias()}.log", 'a') as debugfile:
+        debugfile.write(f"{datetime.now()} <- {data.hex()}\n")
+```
+
+Each line is one notification, timestamped, exactly as the parser sees it. These
+files grow by a few MB per minute per device, so turn debug off when finished.
+
+
+## Testing
+
+Captured notifications make a test that needs no hardware: replay them and
+assert the decoded values. `tests/test_meritsun_parser.py` does this with six
+real notifications and pins voltage, SOC, temperature and capacity — enough to
+catch a framing change without a battery on the desk.

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -18,6 +18,11 @@ Typically, you can have a hierarchy like
   - Characteristics: 0000ffe**3**-0000-1000-8000-00805f9b34fb 
   - Characteristics: 0000ffe**4**-0000-1000-8000-00805f9b34fb 
 
+Short UUIDs are shorthand for the Bluetooth Base UUID
+`0000xxxx-0000-1000-8000-00805f9b34fb`, so `ffe0` and the 128-bit form above
+name the same service. Vendor-defined UUIDs sit outside that base, and have no
+short form: Victron uses `306b0001-…`, Nordic `6e400001-…`.
+
 We then *subscribe to* or *write to* one or more of these characteristics.
 
 Finding these UUIDs, and working out what the bytes mean, is a job of its own:
@@ -25,8 +30,22 @@ Finding these UUIDs, and working out what the bytes mean, is a job of its own:
 with Wireshark. Note that many devices send nothing at all until they receive
 some kind of init.
 
-The shipped plugins are a useful recognition aid. A device advertising one of
-these families probably speaks something close to a protocol already supported:
+## Read the standard services first
+
+Two SIG-assigned services need no reverse engineering:
+
+- `0000180f-…` **Battery Service** — characteristic `00002a19-…` is the state of
+  charge, a single byte, 0–100.
+- `0000180a-…` **Device Information** — `00002a29-…` manufacturer, `00002a24-…`
+  model, `00002a26-…` firmware revision, all plain strings.
+
+A pack that exposes `180f` gives you SOC for free, and `180a` tells you which
+protocol family to expect.
+
+
+## A service UUID identifies the module, not the protocol
+
+The shipped plugins use these:
 
 | Service | Notify characteristic | Used by |
 |---|---|---|
@@ -35,8 +54,18 @@ these families probably speaks something close to a protocol already supported:
 | `306b0001-…` | `306b0002/0003/0004-…` | VEDirect |
 | `6e400001-…` (Nordic UART) | `6e400003-…` | Hacien |
 
-Nordic UART in particular is a generic serial-over-BLE service, so it tells you
-the transport but nothing about the protocol carried over it.
+A match narrows the transport, not the protocol. `0000ffe0-…`/`0000ffe1-…` is
+the factory default of the HM-10 (TI CC2541) serial module, changeable by AT
+command and left alone by most vendors; none of `ffe0`, `fff0`, `ff00` or `ffd0`
+is SIG-assigned. Of the 43 protocols decoded in
+[aiobmsble](https://github.com/patman15/aiobmsble), a dozen mutually
+incompatible ones sit on `ffe0` and another dozen on `fff0`. Nordic UART and
+Microchip/ISSC transparent UART (`49535343-…`) are generic serial-over-BLE
+services in the same way.
+
+The vendor is sometimes in the UUID itself — hex-decode the leading groups.
+`49535343` is ASCII `ISSC`, `57616c6b697a` is `Walkiz`, and Felicity's
+`49535458`/`49535258` are `ISTX`/`ISRX`.
 
 ## Config
 The Config class defines some parameters for the plugin:
@@ -61,6 +90,12 @@ __init__() of the class expects a `PowerDevice` (an object defined in `solardevi
 
 ### Updates
 When we recieve an update, the class function `notificationUpdate(data, char)` is called with the raw data and the UUID of the characteristic we recieved the data from.  This function is then responsible for parsing the data and will then update the `PowerDevice` object.  The function should return True if the message was understood and handled, and False if it was not.
+
+A notification carries at most ATT_MTU − 3 bytes, 20 by default. Frames longer
+than that arrive split across several calls, and one call can hold the tail of
+one frame and the head of the next, so anything longer needs reassembly:
+`Meritsun` buffers the stream and re-syncs on its marker bytes rather than
+trusting notification boundaries.
 
 ### Ack
 The class function `ackData(data)` is required if the device expects an ack for each notification it sends. This function must generate and return a valid "ack-packet" for the received `data`
@@ -91,7 +126,11 @@ something similar should use them rather than growing its own copy:
   `ack_payload()`. Used by `SolarLink` and `RenogyBatt`.
 - `asciihex.py` — `field_value()` for ASCII-hex fields written least significant
   pair first, and `checksum_matches()` for the 16-bit additive checksum. Used by
-  `Meritsun` and `Topband`.
+  `Meritsun` and `Topband`. The same family is documented independently as
+  Topband/Ective in
+  [aiobmsble](https://github.com/patman15/aiobmsble/blob/main/aiobmsble/bms/topband_bms.py)
+  — different frame length and marker bytes, same ASCII-hex payload,
+  little-endian fields, additive checksum and deci-Kelvin temperature.
 - `codec.py` — `to_signed()` and the two's-complement wrap constants, for signed
   readings in any format.
 

--- a/REVERSE-ENGNEER.md
+++ b/REVERSE-ENGNEER.md
@@ -7,6 +7,24 @@ Something is documented, something can be found in other github-repos where some
 
 But after working woth some of the devices for a while, you learn what to look for, and how to interpret the different data.
 
+## Check whether someone has already done it
+
+Before sniffing anything, look for the device in the published corpora:
+
+- [aiobmsble](https://github.com/patman15/aiobmsble) — 43 BMS protocols, one
+  module each, with the service and characteristic UUIDs at the top of every file
+- [dbus-serialbattery](https://github.com/mr-manuel/venus-os_dbus-serialbattery)
+- [syssi's ESPHome components](https://github.com/syssi) — JBD, JK, Seplos and more
+
+Search on the advertised device name and the service UUID. Many of these packs
+are rebadges, and a plugin for the original will usually work unchanged.
+
+Victron is a special case. Its devices broadcast **Instant Readout** in the
+advertisement — manufacturer ID `0x02E1`, record type `0x10`, AES-encrypted with
+a per-device key you can read out of VictronConnect. No connection, no protocol
+to work out; see [victron-ble](https://github.com/keshavdv/victron-ble).
+
+
 ## Requirements
 The easiest way to start is to use an Android phone (maybe an iPhone, I have no idea how those work), the app for the device you want to reverse engieer, a computer with Wireshark and a USB cable for your phone.
 
@@ -37,6 +55,12 @@ Start by opening the bluetooth-dump in Wireshark.
 
 Create a filter with `bluetooth.addr=xx:xx:xx:xx:xx` (the mac-address of your device)
 
+Before a device can send anything, the app has to subscribe, and that
+subscription is in the dump: a write of `0100` to a Client Characteristic
+Configuration descriptor (UUID `2902`). Find those writes first — each one names
+a handle that will carry notifications, which beats working backwards from the
+traffic. `0200` means indications instead, which are acknowledged.
+
 Now you take out your notes and start looking for patterns.
 
 First you start looking whether there are typical "Send Write Command", followed by one or more "Rcvd Handle Value Notification", or if there are just a bunch of "Rcvd Handle Value Notification"
@@ -46,7 +70,7 @@ First you start looking whether there are typical "Send Write Command", followed
 
 In the "Value Notifications", you can find the data from the device.  In Wireshark you will typically see the data as hex-values, use a hex-calculator (can easily be found online if you dont have one), and try out the different values.
 
-If you have multiple Value Notificatons following each other within a short timeframe, or just after a "Write Command", they probably belong together, so you should add them together as one string.
+If you have multiple Value Notificatons following each other within a short timeframe, or just after a "Write Command", they probably belong together, so you should add them together as one string.  A notification holds at most ATT_MTU - 3 bytes, 20 by default, so any frame longer than that is split no matter what the protocol looks like.
 
 For example, if you have received the following hex stream: `01034c0d010d050d030d01ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee49ee490d050d0100020001000405338ad0` split it up into bytes:
 
@@ -135,6 +159,25 @@ And that means that `30D4` = 12500, and the total capacity of the battery is 125
 Just after those, we have a `06` and the app did report 6 charge cycles.  Lets not this down and keep an eye on it after a few charges.
 
 And then just 0 until the checksum.  
+
+### Known protocol families
+
+Recognising the header beats decoding byte by byte:
+
+| Family | Tell |
+|---|---|
+| Modbus RTU | `01 03 <len> …`, ending in a byte-swapped CRC-16/MODBUS |
+| JBD / Xiaoxiang / Overkill Solar | `DD A5 <cmd> <len> … 77` |
+| Jikong (JK) | `55 AA EB 90` in responses, `AA 55 90 EB` in commands |
+| Daly | `D2 03 <len> …` over BLE, Modbus CRC |
+| Seplos v2, Pylontech console | ASCII between `7E` and `0D`, CRC-XMODEM |
+| PACE | `9A` … `9D` |
+| Meritsun, Topband, Ective | marker byte, then ASCII-hex, little-endian fields, 16-bit additive checksum |
+
+The first two bytes and the checksum usually settle it. Once CRC-16/MODBUS
+validates, expect the rest of the Modbus conventions too: function code, byte
+count, big-endian 16-bit registers.
+
 
 ### Summary
 

--- a/REVERSE-ENGNEER.md
+++ b/REVERSE-ENGNEER.md
@@ -148,6 +148,9 @@ I found this after placing the battery outdoors for a few hours, and noticing th
 
 But it is hopefully a simple guide to get you started.  
 
+Once you know the UUIDs and can read the values, [PLUGINS.md](PLUGINS.md)
+describes how to turn that into a plugin.
+
 Good luck.
 
 


### PR DESCRIPTION
`PLUGINS.md` described the BLE model and the two classes a plugin must provide — that part is accurate and untouched. What it did not cover is the parts of the codebase a plugin author would otherwise rewrite.

## Added
- **A UUID recognition table** for the shipped plugins, verified against the source:

  | Service | Notify characteristic | Used by |
  |---|---|---|
  | `0000ffe0-…` | `0000ffe4-…` | Meritsun, Topband |
  | `0000fff0-…` | `0000fff1-…` | SolarLink (SRNE), RenogyBatt |
  | `306b0001-…` | `306b0002/0003/0004-…` | VEDirect |
  | `6e400001-…` (Nordic UART) | `6e400003-…` | Hacien |

  A match narrows the transport, not the protocol — see below.

- **Every characteristic in a `NOTIFY_CHAR_UUID` list is subscribed to** — VEDirect spreads its data across three, and subscribing to one yields no data and a link the device drops.
- **Payloads must be bytes-like.** A list of ints is coerced on the way out, but returning `bytes`/`bytearray` says what you mean.
- **The `modbus`, `asciihex` and `codec` helpers**, and which plugins use each, so a similar device does not grow another copy of CRC validation or ASCII-hex field reading.
- **Capturing what your plugin receives** — `debug = True` makes `Meritsun` and `Hacien` write every notification to `/tmp/<alias>.log`, timestamped, exactly as the parser sees it. That answers a different question from a Wireshark trace of the vendor app, which shows what the *app* negotiated.
- **Testing from a capture** — replay the notifications and assert the decoded values, as `tests/test_meritsun_parser.py` does with six real ones.

## Correlated with REVERSE-ENGNEER.md
The two documents cover consecutive halves of the same job and did not reference each other. `PLUGINS.md` had a paragraph on finding UUIDs by sniffing the vendor app, which is what `REVERSE-ENGNEER.md` covers in detail — that paragraph is now a link, and `REVERSE-ENGNEER.md` ends by pointing at `PLUGINS.md`.

Its pinned permalink into the Meritsun plugin still resolves to the intended docstring, so it is left as is.

Every UUID, helper name and file reference in the new text was checked against the source.

## Well-known UUIDs and protocols (second commit)

Checked against the UUID constants of all 43 plugins in [aiobmsble](https://github.com/patman15/aiobmsble) and the Bluetooth SIG assigned numbers.

- **A service UUID identifies the module, not the protocol.** A dozen mutually incompatible protocols sit on `0000ffe0-…` and another dozen on `0000fff0-…`; none of `ffe0`, `fff0`, `ff00` or `ffd0` is SIG-assigned. `ffe0`/`ffe1` is the factory default of the HM-10 (TI CC2541) serial module. Microchip/ISSC transparent UART (`49535343-…`) joins Nordic UART as a generic serial-over-BLE service. The section heading now says this outright.
- **The Bluetooth base UUID** `0000xxxx-0000-1000-8000-00805f9b34fb`, and which UUIDs have no short form.
- **Read the standard services first** — `180f` Battery Service gives SOC as a plain byte, `180a` Device Information gives manufacturer, model and firmware as strings.
- **Hex-decode the UUID prefix** for the vendor: `49535343` is `ISSC`, `57616c6b697a` is `Walkiz`.
- **ATT_MTU − 3, 20 bytes by default** — the reason `Meritsun` reassembles the stream instead of trusting notification boundaries. Noted in both documents.
- **The `2902` subscription write.** In a Wireshark dump, a write of `0100` to a Client Characteristic Configuration descriptor names a handle that will carry notifications — faster than working backwards from the traffic.
- **A table of protocol families by header** (Modbus RTU, JBD/Xiaoxiang, Jikong, Daly, Seplos v2/Pylontech, PACE, the ASCII-hex family).
- **Check the corpora before sniffing** — `aiobmsble`, `dbus-serialbattery`, syssi's ESPHome components. And Victron needs no reverse engineering at all: Instant Readout is in the advertisement, manufacturer ID `0x02E1`, AES-encrypted with a key from VictronConnect.

Worth noting: aiobmsble's Topband plugin is our Meritsun/Topband family — same ASCII-hex payload, little-endian fields, 16-bit additive checksum and deci-Kelvin temperature, at a different frame length and with different markers. Independent confirmation of the temperature encoding we derived by hand.

