### PR TITLE
Publish multi-arch images from a version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Image
+
+on:
+  push:
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - requirements.txt
+      - .github/workflows/release.yml
+  workflow_dispatch:
+
+jobs:
+  image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      # libscrc has no aarch64 wheel and compiles in the builder stage, so the
+      # arm64 build needs emulation.
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        env:
+          # Annotate the manifest list as well, so registries that read the
+          # index rather than the per-platform config show the metadata.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=long
+          # The repository has no description for metadata-action to derive.
+          labels: |
+            org.opencontainers.image.description=Reads solar regulators, inverters and battery BMSes over Bluetooth LE and publishes to MQTT or HTTP
+          annotations: |
+            org.opencontainers.image.description=Reads solar regulators, inverters and battery BMSes over Bluetooth LE and publishes to MQTT or HTTP
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,11 @@ on:
 
 jobs:
   image:
+    # A pull_request run uses the workflow and Dockerfile from the PR head, so
+    # building one from a fork would execute its RUN steps on the runner.
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,13 @@ WORKDIR /solar-monitor
 COPY --chown=$UID:$GID . .
 USER solar
 
+LABEL org.opencontainers.image.title="solar-monitor" \
+      org.opencontainers.image.description="Reads solar regulators, inverters and battery BMSes over Bluetooth LE and publishes to MQTT or HTTP" \
+      org.opencontainers.image.url="https://github.com/Olen/solar-monitor" \
+      org.opencontainers.image.source="https://github.com/Olen/solar-monitor" \
+      org.opencontainers.image.documentation="https://github.com/Olen/solar-monitor/blob/master/README.md" \
+      org.opencontainers.image.licenses="GPL-3.0-only" \
+      org.opencontainers.image.vendor="Olen" \
+      org.opencontainers.image.base.name="docker.io/library/python:3.11-slim-bookworm"
+
 ENTRYPOINT [ "python", "-u", "solar-monitor.py" ]

--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ The monitor runs fine on a Raspberry Pi zero, making it ideal for monitoring pla
 
 # Docker
 
+Images are published to the GitHub container registry for `linux/amd64` and
+`linux/arm64`:
+
+```
+ghcr.io/olen/solar-monitor:latest
+ghcr.io/olen/solar-monitor:2026.8      # latest patch of that series
+ghcr.io/olen/solar-monitor:2026.8.0    # exact release
+```
+
 To run the service as a container, you can use the included `docker-compose.yaml`
 
 * Copy `solar-monitor.ini.dist` to e.g `~/solar-monitor/solar-monitor.ini`
@@ -49,9 +58,16 @@ To run the service as a container, you can use the included `docker-compose.yaml
 * Run:
 
 ```
-docker-compose up -d
+docker compose pull && docker compose up -d
 ```
-in the same dir as you downloaded these files.  This might take some time, depending on your build host.
+in the same dir as you downloaded these files.
+
+To build the image yourself instead of pulling it, use `docker compose up -d
+--build`. That compiles `libscrc` and takes a while on a Raspberry Pi.
+
+The container runs as uid 1000. If the ini-file and log directory on the host
+belong to a different user, build with `--build-arg UID=... --build-arg GID=...`
+to match.
 
 Check the logs with
 
@@ -237,6 +253,28 @@ This allows you to remotely monitor the data from your installation:
 Each supported device family has a plugin under `plugins/`, responsible for that
 device's framing and decoding. [PLUGINS.md](PLUGINS.md) describes what a plugin
 must provide.
+
+
+# Releases
+
+Pushing a `v`-prefixed tag builds and publishes the image:
+
+```
+git tag -a v2026.8.0 -m "..."
+git push origin v2026.8.0
+```
+
+Versions are `vYYYY.M.PATCH`. The tag produces `2026.8.0`, `2026.8` and
+`latest`, each carrying `org.opencontainers.image.*` metadata — source, revision,
+version, licence and build time:
+
+```
+docker buildx imagetools inspect ghcr.io/olen/solar-monitor:latest
+```
+
+Nothing is published on an ordinary push to `master`. Pull requests that touch
+the `Dockerfile`, `requirements.txt` or the workflow build both architectures
+without pushing.
 
 
 # Licence

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   solar-monitor:
-    build: 
+    image: ghcr.io/olen/solar-monitor:latest
+    build:
       context: .
       network: host
     container_name: solar-monitor


### PR DESCRIPTION
Closes #89.

## Trigger
Nothing is published on a push to `master`. The image is built and pushed when a `v`-prefixed tag is pushed:

```
git tag -a v2026.8.0 -m "..."
git push origin v2026.8.0
```

`workflow_dispatch` allows a manual rebuild. Pull requests that touch `Dockerfile`, `.dockerignore`, `requirements.txt` or the workflow build **both architectures without pushing** — so the arm64 path is exercised on this PR, before any tag exists.

## Tags
`v2026.8.0` produces `2026.8.0`, `2026.8`, `latest` and the full commit sha. Versions follow `vYYYY.M.PATCH`.

## OCI metadata
Static labels are in the `Dockerfile`, so a locally built image carries them too:

```
org.opencontainers.image.title / .description / .url / .source
org.opencontainers.image.documentation / .licenses / .vendor / .base.name
```

`metadata-action` adds `.created`, `.revision` and `.version`, and `DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index` annotates the manifest list as well as each platform config — otherwise registries that read the index show nothing.

`.description` is passed explicitly rather than derived: the repository description is empty, and `metadata-action` would otherwise write an empty label over the one in the `Dockerfile`. Setting a repository description would let it be derived instead.

## Platforms
`linux/amd64` and `linux/arm64` — the cabin host is `aarch64`. arm64 goes through qemu because `libscrc` publishes no aarch64 wheel and compiles in the builder stage; everything else in `requirements.txt` resolves to a wheel. Native arm runners would avoid the emulation at the cost of a build-by-digest and manifest-merge job; worth revisiting if the build time turns out to matter. This PR measures it.

## Verified locally
`docker build` on amd64: labels land as expected and the container still runs as uid 1000, not root.