### PR TITLE
Create the GitHub release from the same tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,12 @@ jobs:
           # The repository has no description for metadata-action to derive.
           labels: |
             org.opencontainers.image.description=Reads solar regulators, inverters and battery BMSes over Bluetooth LE and publishes to MQTT or HTTP
+            org.opencontainers.image.licenses=GPL-3.0-only
           annotations: |
             org.opencontainers.image.description=Reads solar regulators, inverters and battery BMSes over Bluetooth LE and publishes to MQTT or HTTP
+            org.opencontainers.image.documentation=https://github.com/Olen/solar-monitor/blob/master/README.md
+            org.opencontainers.image.vendor=Olen
+            org.opencontainers.image.licenses=GPL-3.0-only
 
       - uses: docker/build-push-action@v6
         with:
@@ -69,3 +73,31 @@ jobs:
           annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  release:
+    needs: image
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists"
+            exit 0
+          fi
+          {
+            printf '```\ndocker pull ghcr.io/%s:%s\n```\n\n' \
+              "${GITHUB_REPOSITORY,,}" "${TAG#v}"
+            gh api "repos/$GITHUB_REPOSITORY/releases/generate-notes" \
+              -f tag_name="$TAG" --jq .body
+          } > notes.md
+          gh release create "$TAG" --title "$TAG" --notes-file notes.md

--- a/README.md
+++ b/README.md
@@ -257,7 +257,8 @@ must provide.
 
 # Releases
 
-Pushing a `v`-prefixed tag builds and publishes the image:
+Pushing a `v`-prefixed tag builds the image, publishes it and creates the
+matching GitHub release:
 
 ```
 git tag -a v2026.8.0 -m "..."
@@ -272,9 +273,12 @@ version, licence and build time:
 docker buildx imagetools inspect ghcr.io/olen/solar-monitor:latest
 ```
 
-Nothing is published on an ordinary push to `master`. Pull requests that touch
-the `Dockerfile`, `requirements.txt` or the workflow build both architectures
-without pushing.
+The release notes are generated from the pull requests merged since the previous
+tag, with the pull command on top.
+
+Nothing is published on an ordinary push to `master`. Pull requests from this
+repository that touch the `Dockerfile`, `requirements.txt` or the workflow build
+both architectures without pushing.
 
 
 # Licence


### PR DESCRIPTION
The `v2026.8.0` tag published the image but left no release behind. This adds a `release` job, gated on the image build succeeding.

- Notes are generated from the pull requests merged since the previous tag (`repos/{}/releases/generate-notes`), with the `docker pull` command prepended.
- No third-party action: `gh` with the built-in `GITHUB_TOKEN` and `contents: write`.
- Idempotent — a re-run of an existing tag exits instead of failing.

Two fixes while in the file:

- `documentation` and `vendor` annotations were on each platform config (from the `Dockerfile`) but missing from the **manifest list**, which is what a registry UI reads.
- `licenses` came out as `GPL-3.0`, a deprecated SPDX identifier that `metadata-action` derives from the repository licence and which overrode the `Dockerfile`'s `GPL-3.0-only`. Now set explicitly.

Verified on the published image: index annotations and per-platform labels both land, and the package is anonymously pullable.

`v2026.8.0` predates this job, so its release is created by hand after merge.