### PR TITLE
Also build linux/arm/v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       # arm64 build needs emulation.
       - uses: docker/setup-qemu-action@v3
         with:
-          platforms: arm64
+          platforms: arm64,arm
 
       - uses: docker/setup-buildx-action@v3
 
@@ -66,7 +66,9 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # arm/v7 is for 32-bit Raspberry Pi OS, which reports linux/arm/v8
+          # on a 64-bit kernel and will not match an arm64 image.
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ The monitor runs fine on a Raspberry Pi zero, making it ideal for monitoring pla
 
 # Docker
 
-Images are published to the GitHub container registry for `linux/amd64` and
-`linux/arm64`:
+Images are published to the GitHub container registry for `linux/amd64`,
+`linux/arm64` and `linux/arm/v7`:
 
 ```
 ghcr.io/olen/solar-monitor:latest
@@ -64,6 +64,11 @@ in the same dir as you downloaded these files.
 
 To build the image yourself instead of pulling it, use `docker compose up -d
 --build`. That compiles `libscrc` and takes a while on a Raspberry Pi.
+
+A 32-bit Raspberry Pi OS on a 64-bit kernel reports its platform as
+`linux/arm/v8` and will not match an `arm64` image; it uses the `arm/v7` one.
+Check with `docker version --format "{{.Server.Arch}}"` — `arm` is 32-bit,
+`aarch64` is 64-bit.
 
 The container runs as uid 1000. If the ini-file and log directory on the host
 belong to a different user, build with `--build-arg UID=... --build-arg GID=...`


### PR DESCRIPTION
The published image does not run on the reference cabin host:

```
no matching manifest for linux/arm/v8 in the manifest list entries
```

That host is a 32-bit Raspberry Pi OS userland on a 64-bit kernel:

```
Server.Arch: arm     dpkg: armhf     LONG_BIT: 32     kernel: aarch64
```

Docker reports the platform as `linux/arm/v8` and will not fall back to `arm64` — 32-bit ARM and `arm64` are different architectures, not variants of one. It does accept `arm/v7` for an `arm/v8` request.

`uname -m` returns `aarch64` there because that is the *kernel*. The userland is what runs in the container, so `docker version --format "{{.Server.Arch}}"` is the check that matters. Documented in the README next to the pull instructions.

`python:3.11-slim-bookworm` publishes `linux/arm/v7`, so the base is available. qemu now sets up `arm` as well as `arm64`.

This PR builds all three platforms without pushing.