### PR TITLE
Rebuild Meritsun frames whose gap fell in the zero fill

### DIFF
--- a/plugins/Meritsun/__init__.py
+++ b/plugins/Meritsun/__init__.py
@@ -53,6 +53,8 @@ class Util():
         self.EOI = 3
         self.START_VAL = 146
         self.END_VAL = 12
+        self.ZERO_CHAR = 0x30
+        self.CONTENT_CHARS = 112   # frame content between the marker and the padding
         self.RecvDataType = self.SOI
         self.RevBuf = [None] * 122
         self.Revindex = 0
@@ -120,6 +122,29 @@ class Util():
                 end = i + 1
         return end
 
+    def _repairZeroFillGap(self, packet):
+        """Rebuild a short frame whose missing bytes fell in the trailing zero run.
+
+        The pack drops chunks of a frame in transit. Between the cell slots and
+        the checksum the frame is a run of '0' characters, so a chunk lost there
+        is restored by padding the run back to full length; the checksum
+        confirms the result. A chunk lost from the fields themselves is gone.
+        """
+        pad = next((i for i in range(1, len(packet)) if packet[i] == self.END_VAL), None)
+        if pad is None:
+            return None
+        content = packet[1:pad]
+        missing = self.CONTENT_CHARS - len(content)
+        if missing <= 0 or len(content) < 40:
+            return None
+        head, checksum = content[:-4], content[-4:]
+        if any(char != self.ZERO_CHAR for char in head[-4:]):
+            return None
+        frame = [0] + list(head) + [self.ZERO_CHAR] * missing + list(checksum)
+        if asciihex.checksum_matches(frame, self.CONTENT_CHARS + 1):
+            return frame
+        return None
+
     def _handleDataPacket(self, packet):
         # The protocol checksum is the only invariant that holds across pack
         # states; field values that look constant are not.
@@ -129,11 +154,19 @@ class Util():
         self.RevBuf = buf
         self.Revindex = min(len(packet), 121)
         self.end = self._frameEnd(packet)
-        if self.end < 60 or not asciihex.checksum_matches(buf, self.end):
-            logging.debug("[%s] frame rejected: len=%d end=%d",
-                          self.PowerDevice.alias(), len(packet), self.end)
-            return False
-        return self.handleMessage(buf[1:self.Revindex], full=len(packet) <= 130)
+        if self.end >= 60 and asciihex.checksum_matches(buf, self.end):
+            return self.handleMessage(buf[1:self.Revindex], full=len(packet) <= 130)
+
+        repaired = self._repairZeroFillGap(packet)
+        if repaired is not None:
+            self.RevBuf = repaired + [0] * (122 - len(repaired))
+            self.Revindex = self.CONTENT_CHARS + 1
+            self.end = self.CONTENT_CHARS + 1
+            return self.handleMessage(repaired[1:self.CONTENT_CHARS + 1], full=True)
+
+        logging.debug("[%s] frame rejected: len=%d end=%d",
+                      self.PowerDevice.alias(), len(packet), self.end)
+        return False
 
 
     def handleMessage(self, message, full=True):

--- a/tests/test_meritsun_parser.py
+++ b/tests/test_meritsun_parser.py
@@ -79,3 +79,49 @@ def test_fragments_are_rejected(util):
     """A truncated frame must not decode: the checksum is the only gate."""
     truncated = [f[:20] for f in CAPTURED_FRAME]
     assert not any(feed(util, truncated))
+
+
+# A frame that lost bytes from its trailing zero run, captured 2026-08-19. The
+# 0x70 in the zero fill is the same packs' byte corruption; it decodes as 0.
+SHORT_FRAME_GAP_IN_ZERO_FILL = [
+    "c937383335303030303030303030303030413039",
+    "3230313030334630303633303033303042383038",
+    "3838374236334530453131304431353044313430",
+    "4430303030303030303030303030303030303030",
+    "3030303030303030703030303030303030303030",
+    "3030303030303030303541460c0c0c0c0c0c0c0c",
+    "c9",
+]
+
+# The same pack, but the loss took part of the field region: unrecoverable.
+SHORT_FRAME_GAP_IN_FIELDS = [
+    "9237413335203030303030303030303030413039",
+    "3230313030334630303633303033303042383038",
+    "3838374236334530453132304431353044313530",
+    "4430303030303030303030303030303030303030",
+    "3030303030303030303030303030303030303030",
+    "3030303030303030301088f8c9",
+]
+
+
+def test_gap_in_the_zero_fill_is_repaired(util):
+    """Bytes lost from the run of '0' are restorable: the checksum proves it."""
+    assert any(feed(util, SHORT_FRAME_GAP_IN_ZERO_FILL))
+    values = util.PowerDevice.entities.values
+    assert values["mvoltage"] == 13688
+    assert values["soc"] == 99
+    assert values["temperature"] == 2864
+    assert values["mcapacity"] == 103072
+    assert values["charge_cycles"] == 63
+
+
+def test_gap_in_the_field_region_is_not_repaired(util):
+    """Only the zero fill can be rebuilt; a lost field must not be invented."""
+    assert not any(feed(util, SHORT_FRAME_GAP_IN_FIELDS))
+
+
+def test_repair_keeps_the_checksum_as_the_gate(util):
+    """A short frame whose checksum cannot be satisfied stays rejected."""
+    frames = list(SHORT_FRAME_GAP_IN_ZERO_FILL)
+    frames[0] = "c937383335303030303030303030303031413039"   # one field altered
+    assert not any(feed(util, frames))


### PR DESCRIPTION
The cabin's battery_1 stopped publishing entirely while the regulator and inverter were unaffected. It is not a regression — the same failure ran for 3.5 h on the previous image, and replaying 4896 captured notifications through the old and new parsers gives identical results.

## What the stream actually looks like

Six minutes of real capture from a 12V100Ah pack:

| | |
|---|---|
| notifications | 4896 (20 bytes each) |
| framed packets | 857 |
| **the full 121 bytes** | **7** |
| too short (chunk lost mid-frame) | 640 |
| too long (marker destroyed, two frames merged) | 210 |
| byte corruption | ~0.3 %, present at HCI — upstream of us |
| **passing the checksum** | **6 (0.7 %)** |

At ~93 frames/min, 0.7 % is about one good frame a minute — just enough to feed the 10-minute refresh. That is why this has worked for months. Nothing regressed; the margin was always this thin, and battery_1 fell below it.

## The fix

`[61:108]` of the frame is a run of `0` characters, and zeros contribute nothing to an additive checksum. Where the lost chunk fell in that run, padding it back to full length reproduces the frame exactly — and the checksum confirms it, so the integrity gate is unchanged.

```
valid as received              6
recovered (gap in zero fill)  28
total                        34   (5.7x)
```

All 34 decode consistently: `soc = 99` (34/34), `temperature = 2864` (34/34), `mvoltage` 13686–13707 mV against 13688–13701 for the independently-verified frames. No false positives.

The rebuild only ever *extends a run of zeros*. Searching the field region too recovers 110 frames, but a third of them decode to nonsense (`soc=0`, `mvoltage=5292807`) from lucky 16-bit checksum hits — a lost field must not be invented.

## What was ruled out

Measured against the same capture, all giving the same 6 frames: marker-to-marker framing, fixed 121-byte stride, anchoring on the invariant prefix, framing on the padding runs, and correcting `_frameEnd` to stop at the first padding byte. Byte-wise majority voting is unusable (only 7 candidates align). Single-bit repair with the checksum as oracle recovers 1 more frame — bit errors are real but are not what breaks the frames.

## Tests

Three, from real captures: a frame with a gap in the zero fill (repaired, values asserted), one damaged in the field region (must stay rejected), and one whose checksum cannot be satisfied (must stay rejected). 154 pass.

## Verified on hardware

Deployed to the cabin Pi before opening this. Both packs have published continuously for 14 minutes — 41 changed values and 48 refreshes — after 8 hours of nothing but connect bursts.