### PR TITLE
Hold the connection interval the Meritsun packs renegotiate away

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
         # runtime deps imported at module level by code under test.
         run: pip install pytest requests python-dateutil
       - name: Byte-compile (syntax gate)
-        run: python -m py_compile monitor_app.py solar-monitor.py supervisor.py solardevice.py datalogger.py duallog.py ble.py connection.py codec.py modbus.py asciihex.py
+        run: python -m py_compile monitor_app.py solar-monitor.py supervisor.py solardevice.py datalogger.py duallog.py ble.py connection.py codec.py modbus.py asciihex.py hci.py
       - name: Run tests
         run: python -m pytest -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,19 @@ RUN pip wheel --no-cache-dir --wheel-dir /wheels -r requirements.txt
 
 FROM python:3.11-slim-bookworm
 
-# bluez provides bluetoothctl, which ble.set_trusted shells out to. bleak
-# reaches D-Bus through pure-python dbus-fast and needs nothing else.
+# bluez provides bluetoothctl, which ble.set_trusted shells out to, and hcitool,
+# which hci.py uses to set the connection interval. bleak reaches D-Bus through
+# pure-python dbus-fast and needs nothing else.
+#
+# hcitool opens a raw HCI socket, so it needs CAP_NET_RAW/CAP_NET_ADMIN. The file
+# capability keeps that to the one binary: the daemon still runs unprivileged.
+# The container must also be started with those capabilities available -- see
+# cap_add in docker-compose.yaml.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends bluez \
+    && apt-get install -y --no-install-recommends bluez libcap2-bin \
+    && setcap cap_net_raw,cap_net_admin+eip /usr/bin/hcitool \
+    && apt-get purge -y libcap2-bin \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /wheels /wheels

--- a/ble.py
+++ b/ble.py
@@ -32,7 +32,7 @@ def _assert_connection_interval(dev):
     """
     interval = getattr(dev, "connection_interval", None)
     if interval:
-        hci.set_connection_interval(dev.mac_address, *interval)
+        hci.set_connection_interval(dev.mac_address, *interval, name=dev.logger_name)
 
 
 def _verify_link(dev):
@@ -53,7 +53,7 @@ def _verify_link(dev):
         return
     logging.warning("[%s] %d of %d frames accepted; re-asserting %g-%g ms",
                     dev.logger_name, accepted, total, *interval)
-    hci.set_connection_interval(dev.mac_address, *interval)
+    hci.set_connection_interval(dev.mac_address, *interval, name=dev.logger_name)
 
 
 async def _hold(dev, client, stop_event, poll_interval, sleep):

--- a/ble.py
+++ b/ble.py
@@ -1,19 +1,65 @@
 """Asyncio BLE transport (bleak) for solar-monitor.
 
-Replaces the abandoned `gatt` library. One asyncio loop (owned by BleManager,
-Task 3) runs in a daemon thread; each device gets one `maintain_device` task.
-bleak uses AcquireNotify for notifications, which — unlike gatt's dbus-signal
-StartNotify — keeps up with high-rate notifiers (the Meritsun batteries).
+One asyncio loop (owned by BleManager) runs in a daemon thread; each device gets
+one `maintain_device` task.
+
+bleak subscribes with BlueZ's StartNotify. Its AcquireNotify path delivers over
+a file descriptor instead of D-Bus, which avoids a known BlueZ notification loss
+(bleak#1343), but measured against the Meritsun packs it makes no difference:
+what those packs lose is lost below D-Bus, at the connection interval. That is
+what `connection_interval` addresses.
 """
 import asyncio
 import logging
 
+import hci
 from connection import backoff_seconds
+
+# How much of the hold loop passes between link-quality checks, and what counts
+# as a healthy link. A link at the interval we ask for accepts ~85% of framed
+# packets; one the peripheral has renegotiated slow accepts under 5%.
+VERIFY_SECONDS = 60.0
+MIN_FRAMES_TO_JUDGE = 20
+MIN_ACCEPT_RATIO = 0.3
+
+
+def _assert_connection_interval(dev):
+    """Ask for the configured interval on a link that has just come up.
+
+    A peripheral may renegotiate the interval a few seconds after connecting,
+    and BlueZ grants it. The packs do this once per connection, so asserting on
+    connect is enough; `_verify_link` covers the rest.
+    """
+    interval = getattr(dev, "connection_interval", None)
+    if interval:
+        hci.set_connection_interval(dev.mac_address, *interval)
+
+
+def _verify_link(dev):
+    """Re-assert the interval when the data says the link has gone slow.
+
+    No HCI command reads the current interval back, but a renegotiated link is
+    unmistakable in the frames: nearly all of them fail the checksum.
+    """
+    interval = getattr(dev, "connection_interval", None)
+    if not interval:
+        return
+    health = dev.frame_health()
+    if not health:
+        return
+    accepted, rejected = health
+    total = accepted + rejected
+    if total < MIN_FRAMES_TO_JUDGE or accepted >= total * MIN_ACCEPT_RATIO:
+        return
+    logging.warning("[%s] %d of %d frames accepted; re-asserting %g-%g ms",
+                    dev.logger_name, accepted, total, *interval)
+    hci.set_connection_interval(dev.mac_address, *interval)
 
 
 async def _hold(dev, client, stop_event, poll_interval, sleep):
     """Hold a resolved connection, polling if the device needs it, until the
     link drops or shutdown is requested."""
+    since_verify = 0.0
     while not stop_event.is_set() and client.is_connected:
         if dev.need_polling and dev.device_write_characteristic_polling:
             data = dev.get_poll_data()
@@ -32,6 +78,10 @@ async def _hold(dev, client, stop_event, poll_interval, sleep):
                     logging.warning("[%s] poll write failed: %r", dev.logger_name, e)
                     break
         await sleep(poll_interval)
+        since_verify += poll_interval
+        if since_verify >= VERIFY_SECONDS:
+            since_verify = 0.0
+            _verify_link(dev)
 
 
 async def maintain_device(dev, connect_lock, client_factory, stop_event,
@@ -63,6 +113,7 @@ async def maintain_device(dev, connect_lock, client_factory, stop_event,
                 for uuid in (notify_uuids or []):
                     await client.start_notify(uuid, dev.notify_callback)
                 connected = True
+            _assert_connection_interval(dev)
             await _hold(dev, client, stop_event, poll_interval, sleep)
         except Exception as e:
             logging.error("[%s] connection error: %r", dev.logger_name, e)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,11 @@ services:
       network: host
     container_name: solar-monitor
     network_mode: host
+    # hcitool needs these to set the connection interval; the file capability in
+    # the image keeps them to that binary. See `connection_interval` in the ini.
+    cap_add:
+      - NET_RAW
+      - NET_ADMIN
     volumes:
       - /var/run/dbus:/var/run/dbus
       - ~/solar-monitor/solar-monitor.ini:/solar-monitor/solar-monitor.ini

--- a/hci.py
+++ b/hci.py
@@ -1,0 +1,78 @@
+"""Set the connection interval of an established BLE link.
+
+BlueZ grants a peripheral's connection-parameter update request whenever it is
+within the spec's absolute bounds -- the kernel's `hci_check_conn_params()` never
+consults the adapter's configured limits -- so a device that asks for a slow
+interval gets one. The Meritsun packs ask for 195 ms and then lose most of every
+frame, because they push ~13 notifications/second into ~5 transmit opportunities.
+
+Neither BlueZ's D-Bus API nor bleak exposes connection parameters, so this goes
+through `hcitool`. That needs CAP_NET_RAW/CAP_NET_ADMIN, granted to the binary
+alone through file capabilities so the daemon keeps running unprivileged; see
+the Dockerfile and `cap_add` in docker-compose.yaml.
+"""
+import logging
+import re
+import subprocess
+
+HCITOOL = "hcitool"
+UNITS_PER_MS = 0.8            # hcitool counts in 1.25 ms units
+
+
+def _run(args):
+    return subprocess.run(args, capture_output=True, text=True, timeout=10)
+
+
+def connection_handle(mac, run=_run):
+    """The controller's handle for an established link, or None."""
+    try:
+        result = run([HCITOOL, "con"])
+    except Exception as error:
+        logging.debug("hcitool con failed: %r", error)
+        return None
+    pattern = re.compile(re.escape(mac.upper()) + r".*?handle (\d+)", re.IGNORECASE)
+    match = pattern.search(result.stdout or "")
+    return match.group(1) if match else None
+
+
+def set_connection_interval(mac, min_ms, max_ms, run=_run):
+    """Ask the controller for a new interval on an established link.
+
+    Returns True when the command was accepted. The peripheral may renegotiate
+    afterwards, which is why callers re-assert on reconnect.
+    """
+    handle = connection_handle(mac, run=run)
+    if handle is None:
+        logging.debug("[%s] no connection handle; cannot set the interval", mac)
+        return False
+    args = [HCITOOL, "lecup", "--handle", handle,
+            "--min", str(round(min_ms * UNITS_PER_MS)),
+            "--max", str(round(max_ms * UNITS_PER_MS)),
+            "--latency", "0", "--timeout", "500"]
+    try:
+        result = run(args)
+    except Exception as error:
+        logging.warning("[%s] setting the connection interval failed: %r", mac, error)
+        return False
+    output = (result.stdout or "") + (result.stderr or "")
+    if result.returncode != 0 or "Operation not permitted" in output or "Could not" in output:
+        logging.warning("[%s] could not set the connection interval: %s",
+                        mac, output.strip() or f"exit {result.returncode}")
+        return False
+    logging.info("[%s] connection interval set to %g-%g ms", mac, min_ms, max_ms)
+    return True
+
+
+def parse_interval(value):
+    """Parse a `min-max` millisecond range from config, or None."""
+    if not value:
+        return None
+    match = re.fullmatch(r"\s*([\d.]+)\s*-\s*([\d.]+)\s*", value)
+    if not match:
+        logging.warning("connection_interval %r is not a 'min-max' range in ms", value)
+        return None
+    low, high = float(match.group(1)), float(match.group(2))
+    if low <= 0 or high < low:
+        logging.warning("connection_interval %r is not a usable range", value)
+        return None
+    return low, high

--- a/hci.py
+++ b/hci.py
@@ -35,15 +35,16 @@ def connection_handle(mac, run=_run):
     return match.group(1) if match else None
 
 
-def set_connection_interval(mac, min_ms, max_ms, run=_run):
+def set_connection_interval(mac, min_ms, max_ms, name="", run=_run):
     """Ask the controller for a new interval on an established link.
 
     Returns True when the command was accepted. The peripheral may renegotiate
-    afterwards, which is why callers re-assert on reconnect.
+    afterwards, which is why callers re-assert on reconnect. `name` is the
+    device's logger name: log lines identify devices by name, never by address.
     """
     handle = connection_handle(mac, run=run)
     if handle is None:
-        logging.debug("[%s] no connection handle; cannot set the interval", mac)
+        logging.debug("[%s] no connection handle; cannot set the interval", name)
         return False
     args = [HCITOOL, "lecup", "--handle", handle,
             "--min", str(round(min_ms * UNITS_PER_MS)),
@@ -52,14 +53,14 @@ def set_connection_interval(mac, min_ms, max_ms, run=_run):
     try:
         result = run(args)
     except Exception as error:
-        logging.warning("[%s] setting the connection interval failed: %r", mac, error)
+        logging.warning("[%s] setting the connection interval failed: %r", name, error)
         return False
     output = (result.stdout or "") + (result.stderr or "")
     if result.returncode != 0 or "Operation not permitted" in output or "Could not" in output:
         logging.warning("[%s] could not set the connection interval: %s",
-                        mac, output.strip() or f"exit {result.returncode}")
+                        name, output.strip() or f"exit {result.returncode}")
         return False
-    logging.info("[%s] connection interval set to %g-%g ms", mac, min_ms, max_ms)
+    logging.info("[%s] connection interval set to %g-%g ms", name, min_ms, max_ms)
     return True
 
 

--- a/plugins/Meritsun/__init__.py
+++ b/plugins/Meritsun/__init__.py
@@ -60,6 +60,8 @@ class Util():
         self.PowerDevice = power_device
         self.end = 0
         self.prev_values = []
+        self._frames_ok = 0
+        self._frames_bad = 0
 
     def notificationUpdate(self, data, char):
         # Gets the binary data from the BLE-device and converts it to a list of hex-values
@@ -130,11 +132,33 @@ class Util():
         self.Revindex = min(len(packet), 121)
         self.end = self._frameEnd(packet)
         if self.end < 60 or not asciihex.checksum_matches(buf, self.end):
+            self._frames_bad += 1
             logging.debug("[%s] frame rejected: len=%d end=%d",
                           self.PowerDevice.alias(), len(packet), self.end)
             return False
+        self._frames_ok += 1
         return self.handleMessage(buf[1:self.Revindex], full=len(packet) <= 130)
 
+    def frame_health(self):
+        """Frames accepted and rejected since the last call."""
+        counts = (self._frames_ok, self._frames_bad)
+        self._frames_ok = self._frames_bad = 0
+        return counts
+
+
+    def _readField(self, message, start, end):
+        """Field value, or None when its characters are not ASCII-hex.
+
+        A byte corrupted onto a "00" pair contributes 0 to the additive checksum
+        whether it parses or not, so the checksum cannot see it and the field
+        silently reads 0. Only the affected field is dropped; the rest of the
+        frame is still good.
+        """
+        if end >= len(message) or not all(
+                0x30 <= char <= 0x39 or 0x41 <= char <= 0x46
+                for char in message[start:end + 1]):
+            return None
+        return asciihex.field_value(message, start, end)
 
     def handleMessage(self, message, full=True):
         # Accepts a list of hex-characters, and returns the human readable values into the powerDevice object
@@ -145,23 +169,45 @@ class Util():
 
         # A real pack always reports a nonzero pack voltage; a frame decoding it as
         # 0 is not a data frame at all -- a cheap backstop behind the checksum.
-        mvoltage = asciihex.field_value(message, 0, 7)
-        if mvoltage < 1000:
+        mvoltage = self._readField(message, 0, 7)
+        if mvoltage is None or mvoltage < 1000:
             return False
 
-        self.PowerDevice.entities.msg = message
         # Scalar fields occupy the first 38 bytes of the frame. They sit at the
         # head, before the region the duplicated fragments corrupt, so they are
         # decoded on every framed packet; each entity setter validates its own
         # value against physical bounds and rejects any that slipped through.
+        mcurrent = self._readField(message, 8, 15)
+        mcapacity = self._readField(message, 16, 23)
+        charge_cycles = self._readField(message, 24, 27)
+        soc = self._readField(message, 28, 31)
+        temperature = self._readField(message, 32, 35)
+        status = self._readField(message, 36, 37)
+
+        # A run of ASCII '0' sums to zero and the checksum field it lands on
+        # reads zero too, so the frame checksum accepts it. A frame carrying a
+        # voltage and nothing else is that run, not a reading.
+        if not any(value for value in
+                   (mcurrent, mcapacity, charge_cycles, soc, temperature, status)
+                   if value is not None):
+            logging.debug("[%s] frame rejected: only the voltage is set",
+                          self.PowerDevice.alias())
+            return False
+
+        self.PowerDevice.entities.msg = message
         self.PowerDevice.entities.mvoltage = mvoltage
-        mcurrent = to_signed(asciihex.field_value(message, 8, 15), UINT32_WRAP, INT32_MAX)
-        self.PowerDevice.entities.mcurrent = mcurrent
-        self.PowerDevice.entities.mcapacity = asciihex.field_value(message, 16, 23)
-        self.PowerDevice.entities.charge_cycles = asciihex.field_value(message, 24, 27)
-        self.PowerDevice.entities.soc = asciihex.field_value(message, 28, 31)
-        self.PowerDevice.entities.temperature = asciihex.field_value(message, 32, 35)
-        self.PowerDevice.entities.status = asciihex.field_value(message, 36, 37)
+        if mcurrent is not None:
+            self.PowerDevice.entities.mcurrent = to_signed(mcurrent, UINT32_WRAP, INT32_MAX)
+        if mcapacity is not None:
+            self.PowerDevice.entities.mcapacity = mcapacity
+        if charge_cycles is not None:
+            self.PowerDevice.entities.charge_cycles = charge_cycles
+        if soc is not None:
+            self.PowerDevice.entities.soc = soc
+        if temperature is not None:
+            self.PowerDevice.entities.temperature = temperature
+        if status is not None:
+            self.PowerDevice.entities.status = status
         # Per-cell voltages start past byte 40 -- exactly the region fragment
         # duplication corrupts. Only trust them on non-bloated ("full") frames;
         # a bloated frame's scalar head is fine but its cells are garbage.

--- a/solar-monitor.ini.dist
+++ b/solar-monitor.ini.dist
@@ -29,6 +29,11 @@ mac = 11:11:11:11:11:11
 [battery_1]
 type = Meritsun
 mac = 11:11:11:11:11:11
+# These packs ask for a 195 ms connection interval once connected, then lose most
+# of every frame because they push ~13 notifications/second into ~5 transmit
+# opportunities. Asking for a fast interval after each connect fixes it. In
+# milliseconds; needs the capabilities described in docker-compose.yaml.
+# connection_interval = 15-30
 
 [battery_2]
 type = Meritsun

--- a/solardevice.py
+++ b/solardevice.py
@@ -5,6 +5,8 @@ import asyncio
 
 import logging
 
+import hci
+
 from connection import write_with_retry
 from supervisor import try_put
 
@@ -82,9 +84,21 @@ class SolarDevice:
             self.entities = PowerDevice(parent=self)
         self.entities.apply_limit_overrides(config, logger_name)
         self.util = self.module.Util(self)
+        self.connection_interval = hci.parse_interval(
+            config.get(logger_name, 'connection_interval', fallback=None)
+            if config else None)
 
     def alias(self):
         return self._alias
+
+    def frame_health(self):
+        """Frames accepted and rejected since the last call, or None.
+
+        The plugin counts them; a link whose interval has been renegotiated
+        slow rejects nearly everything, which no HCI command can report.
+        """
+        health = getattr(self.util, "frame_health", None)
+        return health() if health else None
 
     def set_alias(self, name):
         if name:
@@ -243,7 +257,7 @@ class PowerDevice():
         }
         self._mcapacity = {
             'val': 0,
-            'min': 0,
+            'min': 1,
             'max': 250000,
             'maxdiff': 20000
         }
@@ -791,7 +805,7 @@ class BatteryDevice(PowerDevice):
         }
         self._charge_cycles = {
             'val': 0,
-            'min': 0,
+            'min': 1,
             'max': 10000,
             'maxdiff': 1
         }

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -1,0 +1,107 @@
+"""The connection interval a peripheral renegotiates, and how it is put back."""
+
+import ble
+import hci
+
+
+class _Result:
+    def __init__(self, stdout="", stderr="", returncode=0):
+        self.stdout, self.stderr, self.returncode = stdout, stderr, returncode
+
+
+CONNECTIONS = ("Connections:\n"
+               "\t< LE 7C:01:0A:41:CA:F9 handle 64 state 1 lm CENTRAL \n"
+               "\t< LE C4:F3:12:3B:C7:44 handle 65 state 1 lm CENTRAL \n")
+
+
+def _runner(result=None, calls=None):
+    def run(args):
+        if calls is not None:
+            calls.append(args)
+        if args[1] == "con":
+            return _Result(stdout=CONNECTIONS)
+        return result if result is not None else _Result()
+    return run
+
+
+def test_handle_is_found_case_insensitively():
+    assert hci.connection_handle("7c:01:0a:41:ca:f9", run=_runner()) == "64"
+    assert hci.connection_handle("C4:F3:12:3B:C7:44", run=_runner()) == "65"
+
+
+def test_unknown_mac_has_no_handle():
+    assert hci.connection_handle("11:22:33:44:55:66", run=_runner()) is None
+
+
+def test_milliseconds_become_hcitool_units():
+    """hcitool counts in 1.25 ms units; the config is in milliseconds."""
+    calls = []
+    assert hci.set_connection_interval("7C:01:0A:41:CA:F9", 15, 30, run=_runner(calls=calls))
+    assert calls[-1][:8] == ["hcitool", "lecup", "--handle", "64", "--min", "12", "--max", "24"]
+
+
+def test_a_refused_command_is_reported():
+    """Without the capability hcitool prints an error and exits 0."""
+    run = _runner(result=_Result(stderr="Could not change connection params: "
+                                        "Operation not permitted(1)"))
+    assert not hci.set_connection_interval("7C:01:0A:41:CA:F9", 15, 30, run=run)
+
+
+def test_interval_ranges_are_parsed():
+    assert hci.parse_interval("15-30") == (15.0, 30.0)
+    assert hci.parse_interval(" 7.5 - 15 ") == (7.5, 15.0)
+    for bad in (None, "", "30", "30-15", "0-15", "fast"):
+        assert hci.parse_interval(bad) is None
+
+
+class _Dev:
+    def __init__(self, interval=None, health=None):
+        self.mac_address = "7C:01:0A:41:CA:F9"
+        self.logger_name = "battery_1"
+        self.connection_interval = interval
+        self._health = health
+
+    def frame_health(self):
+        return self._health
+
+
+def test_a_degraded_link_is_re_asserted(monkeypatch):
+    asserted = []
+    monkeypatch.setattr(hci, "set_connection_interval",
+                        lambda mac, lo, hi: asserted.append((mac, lo, hi)))
+    ble._verify_link(_Dev(interval=(15, 30), health=(2, 200)))
+    assert asserted == [("7C:01:0A:41:CA:F9", 15, 30)]
+
+
+def test_a_healthy_link_is_left_alone(monkeypatch):
+    asserted = []
+    monkeypatch.setattr(hci, "set_connection_interval",
+                        lambda mac, lo, hi: asserted.append(mac))
+    ble._verify_link(_Dev(interval=(15, 30), health=(85, 15)))
+    assert asserted == []
+
+
+def test_too_few_frames_to_judge(monkeypatch):
+    """A quiet moment is not a bad link."""
+    asserted = []
+    monkeypatch.setattr(hci, "set_connection_interval",
+                        lambda mac, lo, hi: asserted.append(mac))
+    ble._verify_link(_Dev(interval=(15, 30), health=(0, 3)))
+    assert asserted == []
+
+
+def test_devices_without_a_configured_interval_are_untouched(monkeypatch):
+    asserted = []
+    monkeypatch.setattr(hci, "set_connection_interval",
+                        lambda mac, lo, hi: asserted.append(mac))
+    ble._verify_link(_Dev(interval=None, health=(0, 500)))
+    ble._assert_connection_interval(_Dev(interval=None))
+    assert asserted == []
+
+
+def test_the_interval_is_asserted_on_connect(monkeypatch):
+    asserted = []
+    monkeypatch.setattr(hci, "set_connection_interval",
+                        lambda mac, lo, hi: asserted.append((mac, lo, hi)))
+    ble._assert_connection_interval(_Dev(interval=(15, 30)))
+    assert asserted == [("7C:01:0A:41:CA:F9", 15, 30)]

--- a/tests/test_hci.py
+++ b/tests/test_hci.py
@@ -68,7 +68,7 @@ class _Dev:
 def test_a_degraded_link_is_re_asserted(monkeypatch):
     asserted = []
     monkeypatch.setattr(hci, "set_connection_interval",
-                        lambda mac, lo, hi: asserted.append((mac, lo, hi)))
+                        lambda mac, lo, hi, name="": asserted.append((mac, lo, hi)))
     ble._verify_link(_Dev(interval=(15, 30), health=(2, 200)))
     assert asserted == [("7C:01:0A:41:CA:F9", 15, 30)]
 
@@ -76,7 +76,7 @@ def test_a_degraded_link_is_re_asserted(monkeypatch):
 def test_a_healthy_link_is_left_alone(monkeypatch):
     asserted = []
     monkeypatch.setattr(hci, "set_connection_interval",
-                        lambda mac, lo, hi: asserted.append(mac))
+                        lambda mac, lo, hi, name="": asserted.append(mac))
     ble._verify_link(_Dev(interval=(15, 30), health=(85, 15)))
     assert asserted == []
 
@@ -85,7 +85,7 @@ def test_too_few_frames_to_judge(monkeypatch):
     """A quiet moment is not a bad link."""
     asserted = []
     monkeypatch.setattr(hci, "set_connection_interval",
-                        lambda mac, lo, hi: asserted.append(mac))
+                        lambda mac, lo, hi, name="": asserted.append(mac))
     ble._verify_link(_Dev(interval=(15, 30), health=(0, 3)))
     assert asserted == []
 
@@ -93,7 +93,7 @@ def test_too_few_frames_to_judge(monkeypatch):
 def test_devices_without_a_configured_interval_are_untouched(monkeypatch):
     asserted = []
     monkeypatch.setattr(hci, "set_connection_interval",
-                        lambda mac, lo, hi: asserted.append(mac))
+                        lambda mac, lo, hi, name="": asserted.append(mac))
     ble._verify_link(_Dev(interval=None, health=(0, 500)))
     ble._assert_connection_interval(_Dev(interval=None))
     assert asserted == []
@@ -102,6 +102,6 @@ def test_devices_without_a_configured_interval_are_untouched(monkeypatch):
 def test_the_interval_is_asserted_on_connect(monkeypatch):
     asserted = []
     monkeypatch.setattr(hci, "set_connection_interval",
-                        lambda mac, lo, hi: asserted.append((mac, lo, hi)))
+                        lambda mac, lo, hi, name="": asserted.append((mac, lo, hi)))
     ble._assert_connection_interval(_Dev(interval=(15, 30)))
     assert asserted == [("7C:01:0A:41:CA:F9", 15, 30)]

--- a/tests/test_meritsun_parser.py
+++ b/tests/test_meritsun_parser.py
@@ -79,3 +79,55 @@ def test_fragments_are_rejected(util):
     """A truncated frame must not decode: the checksum is the only gate."""
     truncated = [f[:20] for f in CAPTURED_FRAME]
     assert not any(feed(util, truncated))
+
+
+def test_voltage_only_frame_is_rejected(util):
+    """A run of ASCII '0' passes the additive checksum; it is not a reading.
+
+    Zeros sum to zero and the checksum field the run lands on reads zero, so
+    `checksum_matches` accepts it. Every field but the voltage decoding as 0 is
+    the tell.
+    """
+    message = [0x30] * 112
+    for index, char in enumerate(b"7A35"):          # a plausible pack voltage
+        message[index] = char
+    assert not util.handleMessage(message, full=True)
+    assert util.PowerDevice.entities.values == {}
+
+
+def test_a_real_frame_still_decodes(util):
+    """The zero-fill guard must not reject a frame whose current is legitimately 0."""
+    assert any(feed(util, CAPTURED_FRAME))
+    values = util.PowerDevice.entities.values
+    assert values["mcurrent"] == 0          # pack idle
+    assert values["soc"] == 99
+    assert values["mcapacity"] == 103072
+
+
+def test_a_field_the_checksum_cannot_see_is_dropped(util):
+    """A byte corrupted onto a "00" pair is invisible to the additive checksum.
+
+    Both the true pair and the unparseable one contribute 0, so the frame still
+    validates while the field silently reads 0. Only that field is dropped.
+    """
+    frames = list(CAPTURED_FRAME)
+    corrupted = bytearray(bytes.fromhex(frames[0]))
+    corrupted[11] = 0x20                      # a space inside mcurrent's "00000000"
+    frames[0] = bytes(corrupted).hex()
+
+    assert any(feed(util, frames)), "the frame is still valid and must be used"
+    values = util.PowerDevice.entities.values
+    assert "mcurrent" not in values, "the unreadable field must not be published"
+    assert values["soc"] == 99                # the rest of the frame survives
+    assert values["mcapacity"] == 103072
+    assert values["temperature"] == 2864
+
+
+def test_non_hex_byte_in_the_zero_fill_is_tolerated(util):
+    """Corruption past the fields costs nothing and must not drop anything."""
+    frames = list(CAPTURED_FRAME)
+    corrupted = bytearray(bytes.fromhex(frames[4]))   # deep in the zero fill
+    corrupted[5] = 0x70
+    frames[4] = bytes(corrupted).hex()
+    assert any(feed(util, frames))
+    assert util.PowerDevice.entities.values["soc"] == 99


### PR DESCRIPTION
The cabin's packs stopped publishing for most of a day. The parser was never at fault.

## Cause

The packs ask for a **195 ms connection interval** a few seconds after connecting, and BlueZ grants it — the kernel's `hci_check_conn_params()` only validates the spec's absolute bounds (6–3200) and never consults the adapter's configured limits, so there is no setting that refuses it. At ~13 notifications/second into ~5 transmit opportunities the packs lose most of every frame.

| interval | frames intact | pass checksum | published |
|---|---|---|---|
| 195 ms (what the pack asks for) | 1% | 1% | ~2/min |
| 15 ms (forced) | 93% | 80% | ~40/min |

The regulator asks for 18.75 ms and has never been affected.

## Fix

Neither BlueZ's D-Bus API nor bleak exposes connection parameters ([bleak#149](https://github.com/hbldh/bleak/issues/149)), so `hci.py` drives `hcitool`. It opens a raw HCI socket, so the Dockerfile gives **that binary alone** `cap_net_raw,cap_net_admin+eip` and the compose file adds the matching `cap_add` — the daemon keeps running as uid 1000. Verified: without the file capability the same command fails with `Operation not permitted`; with it, it succeeds as uid 1000 and takes frame integrity to 93%/90%.

A device opts in per section, in milliseconds:

```ini
[battery_1]
type = Meritsun
connection_interval = 15-30
```

Nothing changes for devices without it.

**When it fires.** Measured over a 130 s capture, the packs renegotiate **once per connection**, not repeatedly — every recurrence during debugging was a reconnect. So the interval is asserted after each connect, no timer. As a safety net `_verify_link` re-asserts from inside the existing hold loop when the data says the link went slow: no HCI command reads the interval back, but a renegotiated link rejects nearly every frame and the plugin already counts them (≥20 frames, under 30% accepted).

## Also: corruption the checksum cannot see

A byte corrupted onto a `"00"` pair contributes 0 to the additive checksum whether it parses or not, so the frame still validates while `field_value()` returns its default and the field silently reads 0 — capacity 103072 → 0, cycles 63 → 0. Fields whose characters are not hex are now dropped **individually**, so one bad field no longer discards six good ones. And `_mcapacity`/`_charge_cycles` get `min: 1`, matching `_dsoc`, so a zeroed field can no longer be accepted by the un-latching escape.

Over three real captures this removes every bad reading while keeping 54 of 56 good frames.

## Not the fix

Measured and rejected: bleak's `AcquireNotify` path ([bleak#1343](https://github.com/hbldh/bleak/issues/1343)) — bleak takes it, but at 195 ms it gives the same 1% intact, so the loss is below D-Bus. The `ble.py` docstring claiming otherwise is corrected.

## Tests

10 new (`tests/test_hci.py` plus parser guards), 165 total.