### PR TITLE
Count consecutive rejections in the un-latching escape

### DIFF
--- a/solardevice.py
+++ b/solardevice.py
@@ -658,6 +658,10 @@ class PowerDevice():
         definition = getattr(self, var)
         val = float(val)
         if val == definition['val']:
+            # The device confirming the value it already holds ends any run of
+            # rejected readings: the escape below counts *consecutive* ones.
+            definition['rejected'] = 0
+            definition['rejected_val'] = None
             logging.debug("[{}] Value of {} out of bands: Changed from {} to {} (no diff)".format(self.name, var, definition['val'], val))
             return False
         if val > definition['max']:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -70,3 +70,31 @@ def test_hard_bounds_are_never_escaped(device):
         assert not set_cycles(device, 99999)   # above max
         assert not set_cycles(device, -1)      # below min
     assert device._charge_cycles['val'] == 63
+
+
+def set_soc(dev, value):
+    return dev.validate('_dsoc', value) is None
+
+
+def test_a_confirmed_value_clears_the_reject_run(device):
+    """Rejections must be consecutive, not merely three of them ever.
+
+    A pack at 99% emitted a spurious 67% three times across 4h44m while
+    thousands of good readings arrived in between. Without this, the escape
+    counted them as consecutive and published the bad value.
+    """
+    device._dsoc['val'] = 990
+    assert not set_soc(device, 670)             # 1st reject
+    assert not set_soc(device, 990)             # the pack confirms 99%
+    assert not set_soc(device, 670)             # counts as the 1st again
+    assert not set_soc(device, 670)             # 2nd
+    assert device._dsoc['val'] == 990, "a spurious value must not be believed"
+
+
+def test_a_genuinely_persistent_change_still_gets_through(device):
+    """The escape must still un-latch a real change."""
+    device._dsoc['val'] = 990
+    assert not set_soc(device, 670)
+    assert not set_soc(device, 670)
+    assert set_soc(device, 670)
+    assert device._dsoc['val'] == 670


### PR DESCRIPTION
Found in 10 hours of clean running at the cabin — the only bad value published all night.

```
01:14:23  _dsoc 990 -> 670  rejected 1/3
01:51:23  _dsoc 990 -> 670  rejected 2/3      <- 37 minutes later
05:58:59  accepted after "3 consistent readings"   <- 4h 44m after the first
05:58:59  soc published as 67%
05:59:01  the real 99% fights back through the same gate
```

The escape exists so a monotonic field cannot latch for ever, and its comment says "a spurious reading is transient; a real change persists". But `validate()` returns early when a reading equals the value already held, without clearing the run — so the ~17 000 correct 99% readings that arrived between 01:14 and 05:58 never reset it, and three spurious readings hours apart counted as consecutive.

The fix resets the run on that path. A pack confirming what it already reports ends any run of rejections.

## Tests

Two: a spurious value interleaved with confirmations is never believed, and a genuinely persistent change still un-latches. 167 total.

## Not a fix for this

`_dkelvin` maxdiff — the one temperature warning the same night was `2873 -> 2937`, a 6.4 K jump at 02:48. It was rejected once, never recurred, and the temperature stayed at 14.x through both refreshes either side. That is the guard working; widening `maxdiff` would have published it.