### PR TITLE
Group release notes by label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+# Release notes are generated from the titles of the pull requests merged since
+# the previous tag, so a title is the changelog entry a user reads. Name the
+# behaviour that changed for them, not the code that changed.
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: Fixes
+      labels: [bug]
+    - title: New
+      labels: [enhancement]
+    - title: Devices and protocols
+      labels: [device]
+    - title: Documentation
+      labels: [documentation]
+    - title: Build, CI and dependencies
+      labels: [dependencies, github_actions, ci]
+    - title: Other
+      labels: ["*"]

--- a/README.md
+++ b/README.md
@@ -279,7 +279,10 @@ docker buildx imagetools inspect ghcr.io/olen/solar-monitor:latest
 ```
 
 The release notes are generated from the pull requests merged since the previous
-tag, with the pull command on top.
+tag, with the pull command on top, and grouped by label per
+`.github/release.yml`. A pull request title is therefore the changelog entry
+users read: name the behaviour that changed for them rather than the code that
+changed, and label it so it lands in the right group.
 
 Nothing is published on an ordinary push to `master`. Pull requests from this
 repository that touch the `Dockerfile`, `requirements.txt` or the workflow build


### PR DESCRIPTION
Release notes are generated from the titles of the pull requests merged since the previous tag, so **a pull request title is the changelog entry a user reads**. Two things were wrong with that:

- Titles named the code rather than the behaviour. *"Count consecutive rejections in the un-latching escape"* means nothing to someone running this; *"a one-off bad reading can no longer be accepted hours later"* does.
- Everything appeared in one flat list, so `Create the GitHub release from the same tag` sat beside a fix for batteries going silent, with equal weight.

`.github/release.yml` groups entries by label — Fixes, New, Devices and protocols, Documentation, Build/CI/dependencies — and honours a `skip-changelog` label. Same approach as `homeassistant-plant`.

Added the `ci`, `device` and `skip-changelog` labels, and labelled the already-merged pull requests so regenerated notes categorise correctly.

The README section on releases now states the convention, next to the tagging instructions where it will actually be read.

The notes for `v2026.8.1`, `v2026.8.2` and `v2026.8.3` have been rewritten by hand, since those were generated before this existed.